### PR TITLE
z1591 - change dns setting for systemd-resolve to resolvectl

### DIFF
--- a/src/dns/handler_detectDns_test.go
+++ b/src/dns/handler_detectDns_test.go
@@ -22,7 +22,7 @@ func TestIsValidSystemdResolve(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			RegisterTestingT(t)
 
-			result, err := isValidSystemdResolve(test.filePath)
+			result, err := isValidSystemdResolveResolveConf(test.filePath)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result).To(Equal(test.expected))
 		})

--- a/src/dns/handler_setDns.go
+++ b/src/dns/handler_setDns.go
@@ -31,7 +31,12 @@ func SetDns(dnsServer *dnsServer.Handler, dnsIp net.IP, clientIp net.IP, vpnNetw
 		return nil
 
 	case LocalDnsManagementSystemdResolve:
-		_, err = cmdRunner.Run(exec.Command("systemd-resolve", "--set-dns="+dnsIp.String(), `--set-domain=zerops`, "--interface="+vpnInterfaceName))
+		// resolvectl is multi-binary and behaves differently
+		// based on first command argument it receives (name of the command)
+		// systemd-resolve is only a symlink to resolvectl
+		cmd := exec.Command("resolvectl", "--set-dns="+dnsIp.String(), `--set-domain=zerops`, "--interface="+vpnInterfaceName)
+		cmd.Args[0] = "systemd-resolve"
+		_, err = cmdRunner.Run(cmd)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Command system-resolve [was removed](https://askubuntu.com/questions/1409726/systemd-resolve-command-not-found-in-ubuntu-22-04-desktop) in Ubuntu 22.04. Fixing it to work without it.