### PR TITLE
z1951 - Basic S3 bucket management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.12.3] - 2022-08-16
+
+### Added
+- New set of S3 management `bucket` commands with ability to `create` and `delete` buckets
+  - via `Zerops API`:
+    - `zcli bucket zerops create projectNameOrId serviceName bucketName [flags]`
+    - `zcli bucket zerops delete projectNameOrId serviceName bucketName [flags]`
+  - via `S3 API`.
+    - `zcli bucket s3 create serviceName bucketName [flags]`
+    - `zcli bucket s3 delete serviceName bucketName [flags]`
+
 ## [v0.12.2] - 2022-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.12.3] - 2022-08-16
+
+## [v0.12.4] - 2022-08-24
+
+### Fixed
+- Return correct error messages when project not found by name or ID.
 
 ### Added
 - New set of S3 management `bucket` commands with ability to `create` and `delete` buckets
   - via `Zerops API`:
     - `zcli bucket zerops create projectNameOrId serviceName bucketName [flags]`
     - `zcli bucket zerops delete projectNameOrId serviceName bucketName [flags]`
-  - via `S3 API`.
+  - via `S3 API`:
     - `zcli bucket s3 create serviceName bucketName [flags]`
     - `zcli bucket s3 delete serviceName bucketName [flags]`
+
+## [v0.12.3] - 2022-08-22
+
+### Added
+- PersistentKeepalive for windows VPN clients
 
 ## [v0.12.2] - 2022-08-16
 
 ### Fixed
-- Inherit the `PATH` variable from the user on `daemon install` on `darwin` platform
+- Inherit the `PATH` variable from the user on `daemon install` on `darwin` platform.
 
 ## [v0.12.1] - 2022-08-09
 
 ### Fixed
-- Added missing default URL for region list command
+- Added missing default URL for region list command.
 
 ## [v0.12.0] - 2022-08-08
 
 ### Changed
-- Updated protobufs to the latest version (**!!!breaking change!!! previous zCLI versions are not compatible and will not work**)
-- Updated `protoc-gen` from GitHub to `protoc-gen-go` and `protoc-gen-go-grpc` from GoLang.org
+- Updated protobufs to the latest version (**!!!breaking change!!! previous zCLI versions are not compatible and will not work**).
+- Updated `protoc-gen` from GitHub to `protoc-gen-go` and `protoc-gen-go-grpc` from GoLang.org.
 
 ## [v0.11.4] - 2022-07-26
 - Enable lowercase formatTemplate values, fix length of timestamps.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
-	github.com/zeropsio/zerops-go v1.0.3
+	github.com/zeropsio/zerops-go v1.0.4
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a
 	golang.org/x/text v0.3.7
@@ -26,10 +26,12 @@ require (
 
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
+	github.com/aws/aws-sdk-go v1.44.77 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/aws/aws-sdk-go v1.44.77 h1:m5rTfdv04/swD+vTuS2zn4NEwKX3yEJPMhiVCFDL/mU=
+github.com/aws/aws-sdk-go v1.44.77/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/briandowns/spinner v1.18.1 h1:yhQmQtM1zsqFsouh09Bk/jCjd50pC3EOGsh28gLVvwY=
 github.com/briandowns/spinner v1.18.1/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -193,6 +195,9 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/judwhite/go-svc v1.2.1 h1:a7fsJzYUa33sfDJRF2N/WXhA+LonCEEY8BJb1tuS5tA=
@@ -281,8 +286,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zeropsio/zerops-go v1.0.3 h1:1fe6HNARSVuQmE1eoKgEZzxzUfKsJYQmUOV5JF6/dvA=
-github.com/zeropsio/zerops-go v1.0.3/go.mod h1:Nuqf1xWt53IRLyVoXgR4hF4ICc9jlfOfQgnN3ZhJR3E=
+github.com/zeropsio/zerops-go v1.0.4 h1:FQM1M+/c9GwKezzc6TOvgPl2q3wjem+9JlpWpPQxLgM=
+github.com/zeropsio/zerops-go v1.0.4/go.mod h1:Nuqf1xWt53IRLyVoXgR4hF4ICc9jlfOfQgnN3ZhJR3E=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -742,6 +747,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/src/cliAction/bucket/s3/handler.go
+++ b/src/cliAction/bucket/s3/handler.go
@@ -1,0 +1,27 @@
+package bucketS3
+
+const s3ServerRegion = "us-east-1"
+
+type Config struct {
+	S3StorageAddress string
+}
+
+type RunConfig struct {
+	ServiceStackName string
+	BucketName       string
+	XAmzAcl          string
+	AccessKeyId      string
+	SecretAccessKey  string
+}
+
+type Handler struct {
+	config Config
+}
+
+func New(
+	config Config,
+) *Handler {
+	return &Handler{
+		config: config,
+	}
+}

--- a/src/cliAction/bucket/s3/handler_create.go
+++ b/src/cliAction/bucket/s3/handler_create.go
@@ -1,0 +1,49 @@
+package bucketS3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/zerops-io/zcli/src/constants"
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func (h Handler) Create(ctx context.Context, config RunConfig) error {
+	awsConf := aws.NewConfig().
+		WithEndpoint(h.config.S3StorageAddress).
+		WithRegion(s3ServerRegion).
+		WithS3ForcePathStyle(true).
+		WithCredentials(
+			credentials.NewStaticCredentials(config.AccessKeyId, config.SecretAccessKey, ""),
+		)
+
+	sess, err := session.NewSession(awsConf)
+	if err != nil {
+		return err
+	}
+
+	bucketInput := (&s3.CreateBucketInput{}).
+		SetACL(config.XAmzAcl).
+		SetBucket(config.BucketName)
+
+	if _, err := s3.New(sess).CreateBucketWithContext(ctx, bucketInput); err != nil {
+		var s3Err s3.RequestFailure
+		if errors.As(err, &s3Err) {
+			if s3Err.Code() == s3.ErrCodeBucketAlreadyExists {
+				return errors.New(i18n.BucketS3BucketAlreadyExists)
+			}
+			return fmt.Errorf(i18n.BucketS3RequestFailed, s3Err)
+		}
+		return err
+	}
+
+	fmt.Println(constants.Success + i18n.BucketCreated + i18n.Success)
+
+	return nil
+}

--- a/src/cliAction/bucket/s3/handler_delete.go
+++ b/src/cliAction/bucket/s3/handler_delete.go
@@ -1,0 +1,46 @@
+package bucketS3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/zerops-io/zcli/src/constants"
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func (h Handler) Delete(ctx context.Context, config RunConfig) error {
+	awsConf := aws.NewConfig().
+		WithEndpoint(h.config.S3StorageAddress).
+		WithRegion(s3ServerRegion).
+		WithS3ForcePathStyle(true).
+		WithCredentials(
+			credentials.NewStaticCredentials(config.AccessKeyId, config.SecretAccessKey, ""),
+		)
+
+	sess, err := session.NewSession(awsConf)
+	if err != nil {
+		return err
+	}
+
+	bucketInput := (&s3.DeleteBucketInput{}).
+		SetBucket(config.BucketName).
+		SetExpectedBucketOwner(config.AccessKeyId)
+
+	if _, err := s3.New(sess).DeleteBucketWithContext(ctx, bucketInput); err != nil {
+		var s3Err s3.RequestFailure
+		if errors.As(err, &s3Err) {
+			return fmt.Errorf(i18n.BucketS3RequestFailed, s3Err)
+		}
+		return err
+	}
+
+	fmt.Println(constants.Success + i18n.BucketDeleted + i18n.Success)
+
+	return nil
+}

--- a/src/cliAction/bucket/zerops/handler.go
+++ b/src/cliAction/bucket/zerops/handler.go
@@ -1,0 +1,38 @@
+package bucketZerops
+
+import (
+	"github.com/zerops-io/zcli/src/proto/zBusinessZeropsApiProtocol"
+	"github.com/zerops-io/zcli/src/utils/httpClient"
+	"github.com/zerops-io/zcli/src/utils/sdkConfig"
+)
+
+type Config struct {
+}
+
+type RunConfig struct {
+	ProjectNameOrId  string
+	ServiceStackName string
+	BucketName       string
+	XAmzAcl          string
+}
+
+type Handler struct {
+	config        Config
+	httpClient    *httpClient.Handler
+	apiGrpcClient zBusinessZeropsApiProtocol.ZBusinessZeropsApiProtocolClient
+	sdkConfig     sdkConfig.Config
+}
+
+func New(
+	config Config,
+	httpClient *httpClient.Handler,
+	apiGrpcClient zBusinessZeropsApiProtocol.ZBusinessZeropsApiProtocolClient,
+	sdkConfig sdkConfig.Config,
+) *Handler {
+	return &Handler{
+		config:        config,
+		httpClient:    httpClient,
+		apiGrpcClient: apiGrpcClient,
+		sdkConfig:     sdkConfig,
+	}
+}

--- a/src/cliAction/bucket/zerops/handler_create.go
+++ b/src/cliAction/bucket/zerops/handler_create.go
@@ -1,0 +1,71 @@
+package bucketZerops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/zerops-io/zcli/src/constants"
+	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/proto/zBusinessZeropsApiProtocol"
+	"github.com/zerops-io/zcli/src/utils/projectService"
+	"github.com/zeropsio/zerops-go/dto/input/body"
+	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/sdk"
+	"github.com/zeropsio/zerops-go/sdkBase"
+	"github.com/zeropsio/zerops-go/types"
+	"github.com/zeropsio/zerops-go/types/uuid"
+)
+
+func (h Handler) Create(ctx context.Context, config RunConfig) error {
+	projectId, err := projectService.GetProjectId(ctx, h.apiGrpcClient, config.ProjectNameOrId, h.sdkConfig)
+	if err != nil {
+		return err
+	}
+
+	stack, err := projectService.GetServiceStack(ctx, h.apiGrpcClient, projectId, config.ServiceStackName)
+	if err != nil {
+		return err
+	}
+	if stack.GetServiceStackTypeInfo().GetServiceStackTypeCategory() != zBusinessZeropsApiProtocol.ServiceStackTypeCategory_SERVICE_STACK_TYPE_CATEGORY_OBJECT_STORAGE {
+		return errors.New(i18n.BucketGenericOnlyForObjectStorage)
+	}
+
+	stackId := stack.GetId()
+	bucketName := fmt.Sprintf("%s.%s", strings.ToLower(stackId), config.BucketName)
+
+	fmt.Printf(i18n.BucketCreateCreatingZeropsApi, bucketName)
+	fmt.Println(i18n.BucketGenericBucketNamePrefixed)
+
+	zdk := sdk.New(
+		sdkBase.DefaultConfig(sdkBase.WithCustomEndpoint(h.sdkConfig.RegionUrl)),
+		&http.Client{Timeout: 1 * time.Minute},
+	)
+	authorizedSdk := sdk.AuthorizeSdk(zdk, h.sdkConfig.Token)
+
+	bucketBody := body.PostS3Bucket{
+		Name: types.NewString(bucketName),
+	}
+	if config.XAmzAcl != "" {
+		bucketBody.XAmzAcl = types.NewStringNull(config.XAmzAcl)
+	}
+
+	resp, err := authorizedSdk.PostS3Bucket(
+		ctx,
+		path.ServiceStackIdNamed{ServiceStackId: uuid.ServiceStackId(stackId)},
+		bucketBody,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := resp.Output(); err != nil {
+		return err
+	}
+
+	fmt.Println(constants.Success + i18n.BucketCreated + i18n.Success)
+
+	return nil
+}

--- a/src/cliAction/bucket/zerops/handler_delete.go
+++ b/src/cliAction/bucket/zerops/handler_delete.go
@@ -1,0 +1,65 @@
+package bucketZerops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/zerops-io/zcli/src/constants"
+	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/proto/zBusinessZeropsApiProtocol"
+	"github.com/zerops-io/zcli/src/utils/projectService"
+	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/sdk"
+	"github.com/zeropsio/zerops-go/sdkBase"
+	"github.com/zeropsio/zerops-go/types"
+	"github.com/zeropsio/zerops-go/types/uuid"
+)
+
+func (h Handler) Delete(ctx context.Context, config RunConfig) error {
+	projectId, err := projectService.GetProjectId(ctx, h.apiGrpcClient, config.ProjectNameOrId, h.sdkConfig)
+	if err != nil {
+		return err
+	}
+
+	stack, err := projectService.GetServiceStack(ctx, h.apiGrpcClient, projectId, config.ServiceStackName)
+	if err != nil {
+		return err
+	}
+	if stack.GetServiceStackTypeInfo().GetServiceStackTypeCategory() != zBusinessZeropsApiProtocol.ServiceStackTypeCategory_SERVICE_STACK_TYPE_CATEGORY_OBJECT_STORAGE {
+		return errors.New(i18n.BucketGenericOnlyForObjectStorage)
+	}
+
+	stackId := stack.GetId()
+	bucketName := fmt.Sprintf("%s.%s", strings.ToLower(stackId), config.BucketName)
+
+	fmt.Printf(i18n.BucketDeleteDeletingZeropsApi, bucketName)
+	fmt.Println(i18n.BucketGenericBucketNamePrefixed)
+
+	zdk := sdk.New(
+		sdkBase.DefaultConfig(sdkBase.WithCustomEndpoint(h.sdkConfig.RegionUrl)),
+		&http.Client{Timeout: 1 * time.Minute},
+	)
+	authorizedSdk := sdk.AuthorizeSdk(zdk, h.sdkConfig.Token)
+
+	resp, err := authorizedSdk.DeleteS3(
+		ctx,
+		path.S3Bucket{
+			ServiceStackId: uuid.ServiceStackId(stackId),
+			Name:           types.NewString(bucketName),
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := resp.Output(); err != nil {
+		return err
+	}
+
+	fmt.Println(constants.Success + i18n.BucketDeleted + i18n.Success)
+
+	return nil
+}

--- a/src/cmd/bucket.go
+++ b/src/cmd/bucket.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func bucketCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "bucket", Short: i18n.CmdBucket}
+
+	cmd.AddCommand(bucketZeropsCmd(), bucketS3Cmd())
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.GroupHelp))
+	return cmd
+}
+
+func getXAmzAcl(cmd *cobra.Command) (string, error) {
+	xAmzAcl := params.GetString(cmd, "x-amz-acl")
+	switch xAmzAcl {
+	case "", "private", "public-read", "public-read-write", "authenticated-read":
+		return xAmzAcl, nil
+	}
+
+	return "", errors.New(i18n.BucketGenericXAmzAclInvalid)
+}

--- a/src/cmd/bucketS3.go
+++ b/src/cmd/bucketS3.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func bucketS3Cmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "s3", Short: i18n.CmdBucketS3}
+
+	cmd.AddCommand(bucketS3CreateCmd(), bucketS3DeleteCmd())
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.GroupHelp))
+	return cmd
+}
+
+func getAccessKeys(cmd *cobra.Command, serviceName string) (string, string, error) {
+	accessKeyId := params.GetString(cmd, "accessKeyId")
+	secretAccessKey := params.GetString(cmd, "secretAccessKey")
+
+	// only one of the flags is set
+	if (accessKeyId == "" && secretAccessKey != "") || (accessKeyId != "" && secretAccessKey == "") {
+		return "", "", errors.New(i18n.BucketS3FlagBothMandatory)
+	}
+
+	if accessKeyId == "" && secretAccessKey == "" {
+		if val, ok := os.LookupEnv(serviceName + "_accessKeyId"); ok {
+			accessKeyId = val
+		}
+		if val, ok := os.LookupEnv(serviceName + "_secretAccessKey"); ok {
+			secretAccessKey = val
+		}
+
+		// only one of the env variables was set
+		if (accessKeyId == "" && secretAccessKey != "") || (accessKeyId != "" && secretAccessKey == "") {
+			return "", "", errors.New(i18n.BucketS3EnvBothMandatory)
+		}
+	}
+
+	if accessKeyId == "" || secretAccessKey == "" {
+		return "", "", errors.New(i18n.BucketS3FlagBothMandatory)
+	}
+
+	return accessKeyId, secretAccessKey, nil
+}

--- a/src/cmd/bucketS3Create.go
+++ b/src/cmd/bucketS3Create.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/cliAction/bucket/s3"
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func bucketS3CreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create serviceName bucketName [flags]",
+		Short:        i18n.CmdBucketCreate,
+		Args:         ExactNArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			regSignals(cancel)
+
+			xAmzAcl, err := getXAmzAcl(cmd)
+			if err != nil {
+				return err
+			}
+
+			accessKeyId, secretAccessKey, err := getAccessKeys(cmd, args[0])
+			if err != nil {
+				return err
+			}
+
+			region, err := createRegionRetriever(ctx)
+			if err != nil {
+				return err
+			}
+
+			reg, err := region.RetrieveFromFile()
+			if err != nil {
+				return err
+			}
+
+			bucketName := fmt.Sprintf("%s.%s", strings.ToLower(accessKeyId), args[1])
+
+			fmt.Printf(i18n.BucketCreateCreatingDirect, bucketName)
+			fmt.Println(i18n.BucketGenericBucketNamePrefixed)
+
+			b := bucketS3.New(bucketS3.Config{
+				S3StorageAddress: reg.S3StorageAddress,
+			})
+			return b.Create(ctx, bucketS3.RunConfig{
+				ServiceStackName: args[0],
+				BucketName:       bucketName,
+				XAmzAcl:          xAmzAcl,
+				AccessKeyId:      accessKeyId,
+				SecretAccessKey:  secretAccessKey,
+			})
+		},
+	}
+	params.RegisterString(cmd, "x-amz-acl", "", i18n.BucketGenericXAmzAcl)
+	params.RegisterString(cmd, "accessKeyId", "", i18n.BucketS3AccessKeyId)
+	params.RegisterString(cmd, "secretAccessKey", "", i18n.BucketS3SecretAccessKey)
+
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.BucketCreateHelp))
+	return cmd
+}

--- a/src/cmd/bucketS3Delete.go
+++ b/src/cmd/bucketS3Delete.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/cliAction/bucket/s3"
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func bucketS3DeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete serviceName bucketName [flags]",
+		Short:        i18n.CmdBucketDelete,
+		Args:         ExactNArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			regSignals(cancel)
+
+			accessKeyId, secretAccessKey, err := getAccessKeys(cmd, args[0])
+			if err != nil {
+				return err
+			}
+
+			region, err := createRegionRetriever(ctx)
+			if err != nil {
+				return err
+			}
+
+			reg, err := region.RetrieveFromFile()
+			if err != nil {
+				return err
+			}
+
+			bucketName := fmt.Sprintf("%s.%s", strings.ToLower(accessKeyId), args[1])
+
+			fmt.Printf(i18n.BucketDeleteDeletingDirect, bucketName)
+			fmt.Println(i18n.BucketGenericBucketNamePrefixed)
+
+			b := bucketS3.New(bucketS3.Config{
+				S3StorageAddress: reg.S3StorageAddress,
+			})
+			return b.Delete(ctx, bucketS3.RunConfig{
+				ServiceStackName: args[0],
+				BucketName:       bucketName,
+				AccessKeyId:      accessKeyId,
+				SecretAccessKey:  secretAccessKey,
+			})
+		},
+	}
+	params.RegisterString(cmd, "x-amz-acl", "", i18n.BucketGenericXAmzAcl)
+	params.RegisterString(cmd, "accessKeyId", "", i18n.BucketS3AccessKeyId)
+	params.RegisterString(cmd, "secretAccessKey", "", i18n.BucketS3SecretAccessKey)
+
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.BucketDeleteHelp))
+	return cmd
+}

--- a/src/cmd/bucketZerops.go
+++ b/src/cmd/bucketZerops.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/i18n"
+)
+
+func bucketZeropsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "zerops", Short: i18n.CmdBucketZerops}
+
+	cmd.AddCommand(bucketZeropsCreateCmd(), bucketZeropsDeleteCmd())
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.GroupHelp))
+	return cmd
+}

--- a/src/cmd/bucketZeropsCreate.go
+++ b/src/cmd/bucketZeropsCreate.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/cliAction/bucket/zerops"
+	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/proto/zBusinessZeropsApiProtocol"
+	"github.com/zerops-io/zcli/src/utils/httpClient"
+	"github.com/zerops-io/zcli/src/utils/sdkConfig"
+)
+
+func bucketZeropsCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create projectNameOrId serviceName bucketName [flags]",
+		Short:        i18n.CmdBucketCreate,
+		Args:         ExactNArgs(3),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			regSignals(cancel)
+
+			xAmzAcl, err := getXAmzAcl(cmd)
+			if err != nil {
+				return err
+			}
+
+			storage, err := createCliStorage()
+			if err != nil {
+				return err
+			}
+
+			token, err := getToken(storage)
+			if err != nil {
+				return err
+			}
+
+			region, err := createRegionRetriever(ctx)
+			if err != nil {
+				return err
+			}
+
+			reg, err := region.RetrieveFromFile()
+			if err != nil {
+				return err
+			}
+
+			apiClientFactory := zBusinessZeropsApiProtocol.New(zBusinessZeropsApiProtocol.Config{
+				CaCertificateUrl: reg.CaCertificateUrl,
+			})
+			apiGrpcClient, closeFunc, err := apiClientFactory.CreateClient(
+				ctx,
+				reg.GrpcApiAddress,
+				token,
+			)
+			if err != nil {
+				return err
+			}
+			defer closeFunc()
+
+			client := httpClient.New(ctx, httpClient.Config{
+				HttpTimeout: time.Minute * 15,
+			})
+
+			b := bucketZerops.New(bucketZerops.Config{}, client, apiGrpcClient, sdkConfig.Config{Token: token, RegionUrl: reg.RestApiAddress})
+			return b.Create(ctx, bucketZerops.RunConfig{
+				ProjectNameOrId:  args[0],
+				ServiceStackName: args[1],
+				BucketName:       args[2],
+				XAmzAcl:          xAmzAcl,
+			})
+		},
+	}
+	params.RegisterString(cmd, "x-amz-acl", "", i18n.BucketGenericXAmzAcl)
+
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.BucketCreateHelp))
+	return cmd
+}

--- a/src/cmd/bucketZeropsDelete.go
+++ b/src/cmd/bucketZeropsDelete.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/cliAction/bucket/zerops"
+	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/proto/zBusinessZeropsApiProtocol"
+	"github.com/zerops-io/zcli/src/utils/httpClient"
+	"github.com/zerops-io/zcli/src/utils/sdkConfig"
+)
+
+func bucketZeropsDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete projectNameOrId serviceName bucketName [flags]",
+		Short:        i18n.CmdBucketDelete,
+		Args:         ExactNArgs(3),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			regSignals(cancel)
+
+			storage, err := createCliStorage()
+			if err != nil {
+				return err
+			}
+
+			token, err := getToken(storage)
+			if err != nil {
+				return err
+			}
+
+			region, err := createRegionRetriever(ctx)
+			if err != nil {
+				return err
+			}
+
+			reg, err := region.RetrieveFromFile()
+			if err != nil {
+				return err
+			}
+
+			apiClientFactory := zBusinessZeropsApiProtocol.New(zBusinessZeropsApiProtocol.Config{
+				CaCertificateUrl: reg.CaCertificateUrl,
+			})
+			apiGrpcClient, closeFunc, err := apiClientFactory.CreateClient(
+				ctx,
+				reg.GrpcApiAddress,
+				token,
+			)
+			if err != nil {
+				return err
+			}
+			defer closeFunc()
+
+			client := httpClient.New(ctx, httpClient.Config{
+				HttpTimeout: time.Minute * 15,
+			})
+
+			b := bucketZerops.New(bucketZerops.Config{}, client, apiGrpcClient, sdkConfig.Config{Token: token, RegionUrl: reg.RestApiAddress})
+			return b.Delete(ctx, bucketZerops.RunConfig{
+				ProjectNameOrId:  args[0],
+				ServiceStackName: args[1],
+				BucketName:       args[2],
+			})
+		},
+	}
+
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.BucketDeleteHelp))
+	return cmd
+}

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -86,7 +86,7 @@ func deployCmd() *cobra.Command {
 	params.RegisterString(cmd, "versionName", "", i18n.BuildVersionName)
 	params.RegisterString(cmd, "zeropsYamlPath", "./", i18n.ZeropsYamlLocation)
 
-	cmd.Flags().BoolP("help", "h", false, helpText(i18n.DisplayHelp+i18n.DeployHelp))
+	cmd.Flags().BoolP("help", "h", false, helpText(i18n.DeployHelp))
 
 	return cmd
 }

--- a/src/cmd/di.go
+++ b/src/cmd/di.go
@@ -5,14 +5,12 @@ import (
 	"errors"
 	"time"
 
-	"github.com/zerops-io/zcli/src/i18n"
-
-	"github.com/zerops-io/zcli/src/prolongVpn"
-
 	"github.com/zerops-io/zcli/src/cliStorage"
 	"github.com/zerops-io/zcli/src/constants"
 	"github.com/zerops-io/zcli/src/daemonStorage"
 	"github.com/zerops-io/zcli/src/dnsServer"
+	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/prolongVpn"
 	"github.com/zerops-io/zcli/src/region"
 	"github.com/zerops-io/zcli/src/utils/httpClient"
 	"github.com/zerops-io/zcli/src/utils/logger"

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -7,11 +7,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/zerops-io/zcli/src/i18n"
-
-	"github.com/zerops-io/zcli/src/support"
-
 	"github.com/spf13/cobra"
+
+	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/support"
 	paramsPackage "github.com/zerops-io/zcli/src/utils/params"
 )
 
@@ -40,6 +39,7 @@ func ExecuteCmd() error {
 	rootCmd.AddCommand(regionList())
 	rootCmd.AddCommand(projectCmd())
 	rootCmd.AddCommand(serviceCmd())
+	rootCmd.AddCommand(bucketCmd())
 
 	rootCmd.Flags().BoolP("help", "h", false, helpText(i18n.GroupHelp))
 

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -27,6 +27,8 @@ const (
 	VpnStartHelp      = "the vpn start command."
 	VpnStopHelp       = "the vpn stop command."
 	VpnStatusHelp     = "the vpn status command."
+	BucketCreateHelp  = "the bucket create command."
+	BucketDeleteHelp  = "the bucket delete command."
 
 	// cmd short
 	CmdDeployDesc    = "Deploys your application to Zerops."
@@ -56,12 +58,17 @@ const (
 	CmdServiceStop   = "Stops the Zerops service."
 	CmdServiceDelete = "Deletes the Zerops service."
 	CmdServiceLog    = "Get service runtime or build log to stdout."
+	CmdBucket        = "S3 storage management"
+	CmdBucketZerops  = "Management via Zerops API"
+	CmdBucketS3      = "Management directly via S3 API"
+	CmdBucketCreate  = "Creates a bucket in an existing object storage."
+	CmdBucketDelete  = "Deletes a bucket from an existing object storage."
 
 	// cmd long
 	ProjectImportLong = "Creates a new project with one or more services according to the definition in the import YAML file."
 	DeployDescLong    = "pathToFileOrDir defines a path to one or more directories and/or files relative to the working\ndirectory. The working directory is by default the current directory and can be changed\nusing the --workingDir flag. zCLI deploys selected directories and/or files to Zerops."
 	PushDescLong      = "The command triggers the build pipeline defined in zerops.yml. Zerops.yml must be in the working\ndirectory. The working directory is by default the current directory and can be changed\nusing the --workingDir flag. zCLI uploads all files and subdirectories of the working\ndirectory to Zerops and starts the build pipeline. Files found in the .gitignore\nfile will be ignored.\n\nIf you just want to deploy your application to Zerops, use the zcli deploy command instead."
-	//CmdServiceLogFull = "Returns service runtime or build log to stdout with a streaming option. By default, the command returns the last 100 log messages from all service runtime containers and exits. Use --follow flag to continuously pool for new log messages.\n"
+	// CmdServiceLogFull = "Returns service runtime or build log to stdout with a streaming option. By default, the command returns the last 100 log messages from all service runtime containers and exits. Use --follow flag to continuously pool for new log messages.\n"
 	CmdServiceLogLong    = "Returns service runtime or build log to stdout. By default, the command returns the last 100\nlog messages from all service runtime containers and exits.\n"
 	ServiceLogAdditional = "\nUse the <serviceName> alone in the command to return log messages from all runtime containers.\nSet <serviceName>@1 to return log messages from the first runtime container only.\nSet <serviceName>@build to return log messages from the last build if available."
 	VpnStartLong         = "Starts a VPN session in the selected Zerops project. You can't be connected to multiple projects\nat the same time. If the previous VPN session is active, it will be stopped automatically\nand a new VPN session will start.\n"
@@ -234,6 +241,27 @@ const (
 	// daemon remove
 	DaemonRemoveStopVpnUnavailable = "zerops daemon isn't running, vpn couldn't be removed"
 	DaemonRemoveSuccess            = "zerops daemon has been removed"
+
+	// S3
+	BucketGenericXAmzAcl              = "Defines one of predefined grants, known as canned ACLs.\nValid values are: private, public-read, public-read-write, authenticated-read."
+	BucketGenericXAmzAclInvalid       = "Invalid --x-amz-acl value. Allowed values are: private, public-read, public-read-write, authenticated-read."
+	BucketGenericOnlyForObjectStorage = "This command can be used on object storage services only."
+	BucketGenericBucketNamePrefixed   = "Bucket names are prefixed by object storage service ID to make the bucket names unique.\nLearn more about bucket naming conventions at https://docs.zerops.io/documentation/services/storage/s3.html#used-technology"
+
+	BucketCreated                 = "Bucket created"
+	BucketCreateCreatingDirect    = "Creating bucket %s directly on S3 API.\n"
+	BucketCreateCreatingZeropsApi = "Creating bucket %s using Zerops API.\n"
+
+	BucketDeleted                 = "Bucket deleted"
+	BucketDeleteDeletingDirect    = "Deleting bucket %s directly on S3 API.\n"
+	BucketDeleteDeletingZeropsApi = "Deleting bucket %s using Zerops API.\n"
+
+	BucketS3AccessKeyId         = "When using direct S3 API the accessKeyId to the Zerops object storage is required.\nAutomatically filled if the {serviceName}_accessKeyId environment variable exists."
+	BucketS3SecretAccessKey     = "When using direct S3 API the secretAccessKey to the Zerops object storage is required.\nAutomatically filled if the {serviceName}_secretAccessKey environment variable exists."
+	BucketS3FlagBothMandatory   = "If you are specifying accessKeyId or secretAccessKey, both flags are mandatory."
+	BucketS3EnvBothMandatory    = "If you are using env for accessKeyId or secretAccessKey, both env variables must be set."
+	BucketS3RequestFailed       = "S3 API request failed: %s"
+	BucketS3BucketAlreadyExists = "The bucket name already exists under a different object storage user. Set a different bucket name."
 
 	// generic
 	UnauthenticatedUser = `unauthenticated user, login before proceeding with this command

--- a/src/region/region.go
+++ b/src/region/region.go
@@ -17,6 +17,7 @@ type Data struct {
 	GrpcApiAddress   string `json:"grpcApiAddress"`
 	VpnApiAddress    string `json:"vpnApiAddress"`
 	CaCertificateUrl string `json:"caCertificateUrl"`
+	S3StorageAddress string `json:"s3StorageAddress"`
 }
 
 type Handler struct {

--- a/src/utils/projectService/getProjectById.go
+++ b/src/utils/projectService/getProjectById.go
@@ -6,13 +6,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/zeropsio/zerops-go/errorCode"
-
-	"github.com/zeropsio/zerops-go/apiError"
-
 	"github.com/zerops-io/zcli/src/i18n"
 	"github.com/zerops-io/zcli/src/utils/sdkConfig"
+	"github.com/zeropsio/zerops-go/apiError"
 	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/errorCode"
 	"github.com/zeropsio/zerops-go/sdk"
 	"github.com/zeropsio/zerops-go/sdkBase"
 	"github.com/zeropsio/zerops-go/types/uuid"

--- a/src/utils/projectService/getProjectId.go
+++ b/src/utils/projectService/getProjectId.go
@@ -30,6 +30,10 @@ func GetProjectId(ctx context.Context, apiGrpcClient zBusinessZeropsApiProtocol.
 		return projects[0].GetId(), nil
 	}
 
+	if len(projectNameOrId) != 22 {
+		return "", errors.New(i18n.ProjectNotFound)
+	}
+
 	projectId, err := getById(ctx, sdkConfig, projectNameOrId)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### Added
- New set of S3 management `bucket` commands with ability to `create` and `delete` buckets
  - via `Zerops API`:
    - `zcli bucket zerops create projectNameOrId serviceName bucketName [flags]`
    - `zcli bucket zerops delete projectNameOrId serviceName bucketName [flags]`
  - via `S3 API`.
    - `zcli bucket s3 create serviceName bucketName [flags]`
    - `zcli bucket s3 delete serviceName bucketName [flags]`