### PR TITLE
z2158 - fix deploy on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v0.12.5] - 2022-08-30
+
+### Fixed
+- `zcli deploy` would not work on Windows when certain formats of paths were passed as parameters.
+
 ## [v0.12.4] - 2022-08-24
 
 ### Fixed

--- a/src/cliAction/buildDeploy/handler_deploy.go
+++ b/src/cliAction/buildDeploy/handler_deploy.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/zerops-io/zcli/src/constants"
@@ -18,7 +17,6 @@ import (
 )
 
 func (h *Handler) Deploy(ctx context.Context, config RunConfig) error {
-
 	serviceStack, err := h.checkInputValues(ctx, config)
 	if err != nil {
 		return err
@@ -97,10 +95,10 @@ func getConfigContent(config RunConfig) (*zBusinessZeropsApiProtocol.StringNull,
 	}
 
 	if config.ZeropsYamlPath != nil {
-		workingDir = path.Join(workingDir, *config.ZeropsYamlPath)
+		workingDir = filepath.Join(workingDir, *config.ZeropsYamlPath)
 	}
 
-	zeropsYamlPath := path.Join(workingDir, zeropsYamlFileName)
+	zeropsYamlPath := filepath.Join(workingDir, zeropsYamlFileName)
 
 	zeropsYamlStat, err := os.Stat(zeropsYamlPath)
 	if err != nil {

--- a/src/utils/archiveClient/handler_findGitFiles.go
+++ b/src/utils/archiveClient/handler_findGitFiles.go
@@ -23,7 +23,7 @@ func (h *Handler) FindGitFiles(workingDir string) (res []File, _ error) {
 		filePath = filepath.FromSlash(filePath)
 		return File{
 			SourcePath:  filePath,
-			ArchivePath: filepath.ToSlash(strings.TrimPrefix(filePath, workingDir)),
+			ArchivePath: filepath.ToSlash(strings.TrimPrefix(strings.TrimPrefix(filePath, workingDir), string(os.PathSeparator))),
 		}
 	}
 
@@ -114,8 +114,7 @@ func (h *Handler) listFiles(cmd *exec.Cmd, fn func(path string) error) error {
 
 		if err == io.EOF {
 			if line != "" {
-				err := fn(line)
-				if err != nil {
+				if err := fn(line); err != nil {
 					return err
 				}
 			}
@@ -125,8 +124,7 @@ func (h *Handler) listFiles(cmd *exec.Cmd, fn func(path string) error) error {
 			return err
 		}
 
-		err = fn(line)
-		if err != nil {
+		if err = fn(line); err != nil {
 			return err
 		}
 	}

--- a/src/utils/archiveClient/handler_utils.go
+++ b/src/utils/archiveClient/handler_utils.go
@@ -21,7 +21,7 @@ func (h Handler) fixMissingDirPath(files []File, createFile func(filePath string
 		}
 
 		dirPath += string(os.PathSeparator)
-		if dirPath == file.ArchivePath {
+		if dirPath == filepath.FromSlash(file.ArchivePath) {
 			createdPaths[dirPath] = struct{}{}
 			fixedFiles = append(fixedFiles, file)
 			continue
@@ -38,6 +38,9 @@ func (h Handler) fixMissingDirPath(files []File, createFile func(filePath string
 		// split path into separate folders, to correctly create every folder
 		paths := strings.Split(dirPath, string(os.PathSeparator))
 		for _, p := range paths {
+			if p == "" {
+				continue // if paths ends with PathSeparator, last element will be an empty string, no need to do anything
+			}
 			path = filepath.Join(path, p) + string(os.PathSeparator)
 			if _, ok := createdPaths[path]; ok {
 				continue


### PR DESCRIPTION
Fixed an issue where `zcli deploy` would not work on Windows when certain formats of paths were passed as parameters.