### PR TITLE
z2226 - bucket s3 commands added option to specify region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.12.7] - 2022-09-08
+
+### Added
+- `--region` flag with `REGION` env option to the `zcli bucket s3` `create` and `delete` commands
+ 
 ## [v0.12.6] - 2022-09-01
 
 ### Fixed

--- a/src/cmd/bucketS3.go
+++ b/src/cmd/bucketS3.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/zerops-io/zcli/src/i18n"
+	"github.com/zerops-io/zcli/src/region"
 )
 
 func bucketS3Cmd() *cobra.Command {
@@ -15,6 +17,31 @@ func bucketS3Cmd() *cobra.Command {
 	cmd.AddCommand(bucketS3CreateCmd(), bucketS3DeleteCmd())
 	cmd.Flags().BoolP("help", "h", false, helpText(i18n.GroupHelp))
 	return cmd
+}
+
+func getRegion(ctx context.Context, cmd *cobra.Command) (region.Data, error) {
+	retriever, err := createRegionRetriever(ctx)
+	if err != nil {
+		return region.Data{}, err
+	}
+
+	// prefer region from command parameter or env
+	selectedRegion := params.GetString(cmd, "region")
+
+	// if not provided, try to use the region user is logged to
+	if selectedRegion == "" {
+		reg, err := retriever.RetrieveFromFile()
+		if err != nil {
+			return region.Data{}, err
+		}
+		if reg.Name != "" {
+			return reg, nil
+		}
+	}
+
+	// if no region is found, get a default region
+	regionURL := params.GetString(cmd, "regionURL")
+	return retriever.RetrieveFromURL(regionURL, selectedRegion)
 }
 
 func getAccessKeys(cmd *cobra.Command, serviceName string) (string, string, error) {

--- a/src/cmd/bucketS3Create.go
+++ b/src/cmd/bucketS3Create.go
@@ -31,12 +31,7 @@ func bucketS3CreateCmd() *cobra.Command {
 				return err
 			}
 
-			region, err := createRegionRetriever(ctx)
-			if err != nil {
-				return err
-			}
-
-			reg, err := region.RetrieveFromFile()
+			reg, err := getRegion(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -61,7 +56,16 @@ func bucketS3CreateCmd() *cobra.Command {
 	params.RegisterString(cmd, "x-amz-acl", "", i18n.BucketGenericXAmzAcl)
 	params.RegisterString(cmd, "accessKeyId", "", i18n.BucketS3AccessKeyId)
 	params.RegisterString(cmd, "secretAccessKey", "", i18n.BucketS3SecretAccessKey)
+	params.RegisterString(cmd, "region", "", i18n.BucketS3Region)
 
+	params.RegisterString(cmd, "regionURL", defaultRegionUrl, i18n.RegionUrlFlag)
 	cmd.Flags().BoolP("help", "h", false, helpText(i18n.BucketCreateHelp))
+	cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		if err := command.Flags().MarkHidden("regionURL"); err != nil {
+			return
+		}
+		command.Parent().HelpFunc()(command, strings)
+	})
+
 	return cmd
 }

--- a/src/cmd/bucketS3Delete.go
+++ b/src/cmd/bucketS3Delete.go
@@ -26,12 +26,7 @@ func bucketS3DeleteCmd() *cobra.Command {
 				return err
 			}
 
-			region, err := createRegionRetriever(ctx)
-			if err != nil {
-				return err
-			}
-
-			reg, err := region.RetrieveFromFile()
+			reg, err := getRegion(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -55,7 +50,16 @@ func bucketS3DeleteCmd() *cobra.Command {
 	params.RegisterString(cmd, "x-amz-acl", "", i18n.BucketGenericXAmzAcl)
 	params.RegisterString(cmd, "accessKeyId", "", i18n.BucketS3AccessKeyId)
 	params.RegisterString(cmd, "secretAccessKey", "", i18n.BucketS3SecretAccessKey)
+	params.RegisterString(cmd, "region", "", i18n.BucketS3Region)
 
+	params.RegisterString(cmd, "regionURL", defaultRegionUrl, i18n.RegionUrlFlag)
 	cmd.Flags().BoolP("help", "h", false, helpText(i18n.BucketDeleteHelp))
+	cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		if err := command.Flags().MarkHidden("regionURL"); err != nil {
+			return
+		}
+		command.Parent().HelpFunc()(command, strings)
+	})
+
 	return cmd
 }

--- a/src/cmd/login.go
+++ b/src/cmd/login.go
@@ -38,7 +38,7 @@ func loginCmd() *cobra.Command {
 			regionURL := params.GetString(cmd, "regionURL")
 			regionName := params.GetString(cmd, "region")
 
-			reg, err := region.RetrieveFromURL(regionURL, regionName)
+			reg, err := region.RetrieveFromURLAndSave(regionURL, regionName)
 			if err != nil {
 				return err
 			}
@@ -69,12 +69,11 @@ func loginCmd() *cobra.Command {
 	params.RegisterString(cmd, "zeropsPassword", "", i18n.ZeropsPwdFlag)
 	params.RegisterString(cmd, "zeropsToken", "", i18n.ZeropsTokenFlag)
 	params.RegisterString(cmd, "region", "", i18n.RegionFlag)
-	params.RegisterString(cmd, "regionURL", "https://api.app.zerops.io/api/rest/public/region/zcli", i18n.RegionUrlFlag)
+	params.RegisterString(cmd, "regionURL", defaultRegionUrl, i18n.RegionUrlFlag)
 
 	cmd.Flags().BoolP("help", "h", false, helpText(i18n.LoginHelp))
 	cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		err := command.Flags().MarkHidden("regionURL")
-		if err != nil {
+		if err := command.Flags().MarkHidden("regionURL"); err != nil {
 			return
 		}
 		command.Parent().HelpFunc()(command, strings)

--- a/src/cmd/regionList.go
+++ b/src/cmd/regionList.go
@@ -9,6 +9,8 @@ import (
 	"github.com/zerops-io/zcli/src/i18n"
 )
 
+const defaultRegionUrl = "https://api.app.zerops.io/api/rest/public/region/zcli"
+
 func regionList() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "region",
@@ -45,12 +47,11 @@ func regionList() *cobra.Command {
 			return nil
 		},
 	}
-	params.RegisterString(listCmd, "regionURL", "https://api.app.zerops.io/api/rest/public/region/zcli", "zerops region")
+	params.RegisterString(listCmd, "regionURL", defaultRegionUrl, "zerops region")
 	listCmd.Flags().BoolP("help", "h", false, helpText(i18n.RegionListHelp))
 
 	listCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		err := command.Flags().MarkHidden("regionURL")
-		if err != nil {
+		if err := command.Flags().MarkHidden("regionURL"); err != nil {
 			return
 		}
 		command.Parent().HelpFunc()(command, strings)

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -256,6 +256,7 @@ const (
 	BucketDeleteDeletingDirect    = "Deleting bucket %s directly on S3 API.\n"
 	BucketDeleteDeletingZeropsApi = "Deleting bucket %s using Zerops API.\n"
 
+	BucketS3Region              = "When using direct S3 API choose one of Zerops regions.\nUse the \"zcli region list\" command to list all Zerops regions.\nAutomatically filled if the REGION environment variable exists or the user is logged in."
 	BucketS3AccessKeyId         = "When using direct S3 API the accessKeyId to the Zerops object storage is required.\nAutomatically filled if the {serviceName}_accessKeyId environment variable exists."
 	BucketS3SecretAccessKey     = "When using direct S3 API the secretAccessKey to the Zerops object storage is required.\nAutomatically filled if the {serviceName}_secretAccessKey environment variable exists."
 	BucketS3FlagBothMandatory   = "If you are specifying accessKeyId or secretAccessKey, both flags are mandatory."

--- a/src/region/region.go
+++ b/src/region/region.go
@@ -29,12 +29,22 @@ func New(client *httpClient.Handler, storage *storage.Handler[Data]) *Handler {
 	return &Handler{storage: storage, client: client}
 }
 
+// RetrieveFromURL retrieves the region from URL, if region is empty, returns a default region
 func (h *Handler) RetrieveFromURL(regionURL, region string) (Data, error) {
 	resp, err := h.client.Get(regionURL)
 	if err != nil {
 		return Data{}, err
 	}
 	reg, err := readRegion(region, resp.Body)
+	if err != nil {
+		return Data{}, err
+	}
+	return reg, nil
+}
+
+// RetrieveFromURLAndSave retrieves the region using RetrieveFromURL and stores it into the file
+func (h *Handler) RetrieveFromURLAndSave(regionURL, region string) (Data, error) {
+	reg, err := h.RetrieveFromURL(regionURL, region)
 	if err != nil {
 		return Data{}, err
 	}


### PR DESCRIPTION
## [v0.12.7] - 2022-09-08

### Added
- `--region` flag with `ZCLI_REGION` env option to the `zcli bucket s3` `create` and `delete` commands