### PR TITLE
z2941 - fix uint params ignoring env and config values

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,7 +13,7 @@ jobs:
         include:
           - name: linux amd64
             os: ubuntu-latest
-            buildCmd: env GOOS=linux GOARCH=amd64 go build -o builds/zcli-linux-amd64 -ldflags "-X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
+            buildCmd: env GOOS=linux GOARCH=amd64 go build -o builds/zcli-linux-amd64 -ldflags "-s -w -X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
             file: zcli-linux-amd64
             compress: true
             strip: true
@@ -21,7 +21,7 @@ jobs:
             runTests: true
           - name: linux 386
             os: ubuntu-latest
-            buildCmd: env GOOS=linux GOARCH=386 go build -o builds/zcli-linux-i386 -ldflags "-X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
+            buildCmd: env GOOS=linux GOARCH=386 go build -o builds/zcli-linux-i386 -ldflags "-s -w -X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
             file: zcli-linux-i386
             compress: true
             strip: true
@@ -29,7 +29,7 @@ jobs:
             runTests: true
           - name: darwin amd64
             os: macos-latest
-            buildCmd: env GOOS=darwin GOARCH=amd64 go build -o builds/zcli-darwin-amd64 -ldflags "-X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
+            buildCmd: env GOOS=darwin GOARCH=amd64 go build -o builds/zcli-darwin-amd64 -ldflags "-s -w -X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
             file: zcli-darwin-amd64
             compress: false
             strip: false
@@ -37,7 +37,7 @@ jobs:
             runTests: true
           - name: darwin arm64
             os: macos-latest
-            buildCmd: env GOOS=darwin GOARCH=arm64 go build -o builds/zcli-darwin-arm64 -ldflags "-X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
+            buildCmd: env GOOS=darwin GOARCH=arm64 go build -o builds/zcli-darwin-arm64 -ldflags "-s -w -X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
             file: zcli-darwin-arm64
             compress: false
             strip: false
@@ -45,7 +45,7 @@ jobs:
             runTests: false
           - name: windows amd64
             os: ubuntu-latest
-            buildCmd: env GOOS=windows GOARCH=amd64 go build -o builds/zcli-win-x64.exe -ldflags "-X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
+            buildCmd: env GOOS=windows GOARCH=amd64 go build -o builds/zcli-win-x64.exe -ldflags "-s -w -X github.com/zeropsio/zcli/src/cmd.Version=${{ github.event.release.tag_name }}" ./cmd/main.go
             file: zcli-win-x64.exe
             compress: false
             strip: false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tools/npm/node_modules
 *zerops.yml
 *import.yml
 *.DS_Store
+# ignore built binary in root dir
+/zcli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.12.19] - 2023-02-24
+
+### Fixed
+- `service log` and `vpn start` were ignoring env and config values for `limit` and `mtu` parameters respectively
+
+### Changed
+- released binaries do not include debug tables and should be about 25% to 30% smaller
+- `push` command now correctly pushes all files if called from a repository utilizing git submodules
+
 ## [v0.12.18] - 2023-01-21
 
 ### Added

--- a/src/utils/archiveClient/handler_findGitFiles.go
+++ b/src/utils/archiveClient/handler_findGitFiles.go
@@ -59,7 +59,7 @@ func (h *Handler) FindGitFiles(workingDir string) (res []File, _ error) {
 
 	// add all non deleted
 	if err := h.listFiles(
-		createCmd("git", "ls-files", "--exclude-standard"),
+		createCmd("git", "ls-files", "--exclude-standard", "--recurse-submodules"),
 		func(path string) error {
 			if _, exists := excludedFiles[path]; !exists {
 				res = append(res, createFile(filepath.Join(workingDir, path)))

--- a/src/utils/params/handler.go
+++ b/src/utils/params/handler.go
@@ -27,60 +27,54 @@ func (h *Handler) getCmdId(cmd *cobra.Command, name string) string {
 }
 
 func (h *Handler) RegisterString(cmd *cobra.Command, name, defaultValue, description string) {
-
 	var paramValue string
 
-	cmd.Flags().StringVar(&paramValue, name, "", description)
+	cmd.Flags().StringVar(&paramValue, name, defaultValue, description)
 
 	h.params[h.getCmdId(cmd, name)] = func() *string {
-		if paramValue != "" {
+		if cmd.Flags().Lookup(name).Changed {
 			return &paramValue
 		}
 		if h.viper.GetString(name) != "" {
 			v := h.viper.GetString(name)
 			return &v
 		}
-
-		return &defaultValue
+		return &paramValue
 	}
 }
 
 func (h *Handler) RegisterBool(cmd *cobra.Command, name string, defaultValue bool, description string) {
-
 	var paramValue bool
 
-	cmd.Flags().BoolVar(&paramValue, name, false, description)
+	cmd.Flags().BoolVar(&paramValue, name, defaultValue, description)
 
 	h.params[h.getCmdId(cmd, name)] = func() *bool {
-		if paramValue != false {
+		if cmd.Flags().Lookup(name).Changed {
 			return &paramValue
 		}
 		if h.viper.GetBool(name) != false {
 			v := h.viper.GetBool(name)
 			return &v
 		}
-
-		return &defaultValue
+		return &paramValue
 	}
 }
 
 func (h *Handler) RegisterPersistentString(cmd *cobra.Command, name, defaultValue, description string) {
-
 	var paramValue string
 
-	cmd.PersistentFlags().StringVar(&paramValue, name, "", description)
+	cmd.PersistentFlags().StringVar(&paramValue, name, defaultValue, description)
 	h.viper.BindPFlags(cmd.PersistentFlags())
 
 	h.params[name] = func() *string {
-		if paramValue != "" {
+		if cmd.Flags().Lookup(name).Changed {
 			return &paramValue
 		}
 		if h.viper.GetString(name) != "" {
 			v := h.viper.GetString(name)
 			return &v
 		}
-
-		return &defaultValue
+		return &paramValue
 	}
 }
 
@@ -90,18 +84,14 @@ func (h *Handler) RegisterUInt32(cmd *cobra.Command, name string, defaultValue u
 	cmd.Flags().Uint32Var(&paramValue, name, defaultValue, description)
 
 	h.params[name] = func() *uint32 {
-		if paramValue > 0 {
+		if cmd.Flags().Lookup(name).Changed {
 			return &paramValue
 		}
 		if h.viper.GetUint32(name) != 0 {
 			v := h.viper.GetUint32(name)
 			return &v
 		}
-		if paramValue == 0 {
-			return &paramValue
-		}
-
-		return &defaultValue
+		return &paramValue
 	}
 }
 
@@ -167,7 +157,6 @@ func (h *Handler) GetBool(cmd *cobra.Command, name string) bool {
 }
 
 func (h *Handler) InitViper() error {
-
 	path, err := os.Getwd()
 	if err != nil {
 		return err


### PR DESCRIPTION
### Fixed
- `service log` and `vpn start` were ignoring env and config values for `limit` and `mtu` parameters respectively

### Changed
- released binaries do not include debug tables and should be about 25% to 30% smaller
- `push` command now correctly pushes all files if called from a repository utilizing git submodules
