### PR TITLE
Remove non ascii file from repo, to fix broken go get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.19] - 2023-06-06
+
+### Fixed
+- `go get` would fail due to the `non–ascii.txt` file in one of the test cases. File is now created ad-hoc during the test and then cleaned up.
+
 ## [v0.12.19] - 2023-02-24
 
 ### Fixed

--- a/src/archiveClient/handler_findFilesByRules_test.go
+++ b/src/archiveClient/handler_findFilesByRules_test.go
@@ -223,6 +223,12 @@ var findByRulesTestCases = []struct {
 }
 
 func TestFindFilesByRules(t *testing.T) {
+	def, err := createNonAsciiFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer def()
+
 	ctrl := gomock.NewController(t)
 	uxBlocks := mocks.NewMockUxBlocks(ctrl)
 	uxBlocks.EXPECT().PrintInfo(gomock.Any()).AnyTimes()

--- a/src/archiveClient/handler_findGitFiles_test.go
+++ b/src/archiveClient/handler_findGitFiles_test.go
@@ -2,6 +2,7 @@ package archiveClient
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,12 @@ var findGitFilesTestCases = []struct {
 }
 
 func TestFindGitFiles(t *testing.T) {
+	def, err := createNonAsciiFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer def()
+
 	ctx := context.TODO()
 	for _, test := range findGitFilesTestCases {
 		t.Run(test.name+"-in-"+test.workingDir, func(t *testing.T) {
@@ -47,4 +54,17 @@ func TestFindGitFiles(t *testing.T) {
 			assert.Equal(test.output, output)
 		})
 	}
+}
+
+// creates a non ascii file and returns a function to clean it up afterward
+// needs to be done like this, otherwise `go get` fails on "malformed file path"
+func createNonAsciiFile() (func(), error) {
+	file, err := os.Create("./test/var/www/non–ascii.txt")
+	if err != nil {
+		return nil, err
+	}
+	return func() {
+		file.Close()
+		os.Remove(file.Name())
+	}, nil
 }


### PR DESCRIPTION
## [v1.0.19] - 2023-06-06

### Fixed
- `go get` would fail due to the `non–ascii.txt` file in one of the test cases. File is now created ad-hoc during the test and then cleaned up.