### PR TITLE
improvement: don't ask for projectId when serviceId is provided

### DIFF
--- a/src/cmd/scope/scopeProject.go
+++ b/src/cmd/scope/scopeProject.go
@@ -21,10 +21,6 @@ type project struct {
 
 const ProjectArgName = "projectId"
 
-func (p *project) GetParent() cmdBuilder.ScopeLevel {
-	return nil
-}
-
 func (p *project) AddCommandFlags(cmd *cmdBuilder.Cmd) {
 	cmd.StringFlag(ProjectArgName, "", i18n.T(i18n.ProjectIdFlag))
 }

--- a/src/cmdBuilder/buildCobraCmd.go
+++ b/src/cmdBuilder/buildCobraCmd.go
@@ -39,8 +39,8 @@ func buildCobraCmd(
 	}
 	cobraCmd.Use = strings.Join(append([]string{cmd.use}, argNames...), " ")
 
-	for _, dep := range getScopeListFromRoot(cmd.scopeLevel) {
-		dep.AddCommandFlags(cmd)
+	if cmd.scopeLevel != nil {
+		cmd.scopeLevel.AddCommandFlags(cmd)
 	}
 
 	for _, flag := range cmd.flags {

--- a/src/cmdBuilder/cmd.go
+++ b/src/cmdBuilder/cmd.go
@@ -10,7 +10,6 @@ type guestRunFunc func(ctx context.Context, cmdData *GuestCmdData) error
 type ScopeLevel interface {
 	AddCommandFlags(*Cmd)
 	LoadSelectedScope(ctx context.Context, cmd *Cmd, cmdData *LoggedUserCmdData) error
-	GetParent() ScopeLevel
 }
 
 type Cmd struct {

--- a/src/cmdBuilder/createRunFunc.go
+++ b/src/cmdBuilder/createRunFunc.go
@@ -3,7 +3,6 @@ package cmdBuilder
 import (
 	"fmt"
 	"os"
-	"slices"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -122,12 +121,12 @@ func createCmdRunFunc(
 
 		cmdData.RestApiClient = zeropsRestApiClient.NewAuthorizedClient(token, "https://"+storedData.RegionData.Address)
 
-		for _, dep := range getScopeListFromRoot(cmd.scopeLevel) {
-			err := dep.LoadSelectedScope(ctx, cmd, cmdData)
-			if err != nil {
+		if cmd.scopeLevel != nil {
+			if err := cmd.scopeLevel.LoadSelectedScope(ctx, cmd, cmdData); err != nil {
 				return err
 			}
 		}
+
 		return cmd.loggedUserRunFunc(ctx, cmdData)
 	}
 }
@@ -169,19 +168,4 @@ func convertArgs(cmd *Cmd, args []string) (map[string][]string, error) {
 	}
 
 	return argsMap, nil
-}
-
-func getScopeListFromRoot(dep ScopeLevel) []ScopeLevel {
-	var list []ScopeLevel
-	for {
-		if dep == nil {
-			break
-		}
-		list = append(list, dep)
-		dep = dep.GetParent()
-	}
-
-	slices.Reverse(list)
-
-	return list
 }


### PR DESCRIPTION
#### What Type of Change is this?

- [ ] New Feature
- [ ] Minor Fix
- [x] Minor Improvement
- [ ] Other

#### Description (required)

Removes the need to provide the `--projectId` flag for service scope commands when the `--serviceId` flag is provided.