### PR TITLE
feat(import): allow to take yaml content from stdin in import commands

### DIFF
--- a/src/cmd/projectImport.go
+++ b/src/cmd/projectImport.go
@@ -23,7 +23,7 @@ func projectImportCmd() *cmdBuilder.Cmd {
 		Long(i18n.T(i18n.CmdDescProjectImportLong)).
 		Arg(projectImportArgName).
 		StringFlag("orgId", "", i18n.T(i18n.OrgIdFlag)).
-		StringFlag("workingDie", "./", i18n.T(i18n.BuildWorkingDir)).
+		StringFlag("workingDir", "./", i18n.T(i18n.BuildWorkingDir)).
 		HelpFlag(i18n.T(i18n.CmdHelpProjectImport)).
 		LoggedUserRunFunc(func(ctx context.Context, cmdData *cmdBuilder.LoggedUserCmdData) error {
 			uxBlocks := cmdData.UxBlocks
@@ -33,13 +33,21 @@ func projectImportCmd() *cmdBuilder.Cmd {
 				return err
 			}
 
-			yamlContent, err := yamlReader.ReadContent(
-				uxBlocks,
-				cmdData.Args[projectImportArgName][0],
-				cmdData.Params.GetString("workingDir"),
-			)
-			if err != nil {
-				return err
+			var yamlContent []byte
+			if cmdData.Args[projectImportArgName][0] == "-" {
+				yamlContent, err = yamlReader.ReadContentFromStdin(uxBlocks)
+				if err != nil {
+					return err
+				}
+			} else {
+				yamlContent, err = yamlReader.ReadContent(
+					uxBlocks,
+					cmdData.Args[projectImportArgName][0],
+					cmdData.Params.GetString("workingDir"),
+				)
+				if err != nil {
+					return err
+				}
 			}
 
 			importProjectResponse, err := cmdData.RestApiClient.PostProjectImport(

--- a/src/cmd/projectServiceImport.go
+++ b/src/cmd/projectServiceImport.go
@@ -25,9 +25,22 @@ func projectServiceImportCmd() *cmdBuilder.Cmd {
 		LoggedUserRunFunc(func(ctx context.Context, cmdData *cmdBuilder.LoggedUserCmdData) error {
 			uxBlocks := cmdData.UxBlocks
 
-			yamlContent, err := yamlReader.ReadContent(uxBlocks, cmdData.Args[serviceImportArgName][0], "./")
-			if err != nil {
-				return err
+			var err error
+			var yamlContent []byte
+			if cmdData.Args[serviceImportArgName][0] == "-" {
+				yamlContent, err = yamlReader.ReadContentFromStdin(uxBlocks)
+				if err != nil {
+					return err
+				}
+			} else {
+				yamlContent, err = yamlReader.ReadContent(
+					uxBlocks,
+					cmdData.Args[serviceImportArgName][0],
+					"./",
+				)
+				if err != nil {
+					return err
+				}
 			}
 
 			importServiceResponse, err := cmdData.RestApiClient.PostServiceStackImport(

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -67,13 +67,13 @@ and your %s.`,
 	ProjectDeleted:       "Project was deleted",
 
 	// project import
-	CmdHelpProjectImport:     "the project import command.",
+	CmdHelpProjectImport:     "The project import command. Use \"-\" as importYamlPath for taking yaml content from stdin.",
 	CmdDescProjectImport:     "Creates a new project with one or more services.",
 	CmdDescProjectImportLong: "Creates a new project with one or more services according to the definition in the import YAML file.",
 	ProjectImported:          "project imported",
 
 	// project service import
-	CmdHelpProjectServiceImport: "the project service import command.",
+	CmdHelpProjectServiceImport: "The project service import command. Use \"-\" as importYamlPath for taking yaml content from stdin.",
 	CmdDescProjectServiceImport: "Creates one or more Zerops services in an existing project.",
 	ServiceImported:             "service(s) imported",
 

--- a/src/yamlReader/readYaml.go
+++ b/src/yamlReader/readYaml.go
@@ -1,11 +1,14 @@
 package yamlReader
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"github.com/zeropsio/zcli/src/i18n"
 	"github.com/zeropsio/zcli/src/uxBlock"
 	"github.com/zeropsio/zcli/src/uxBlock/styles"
@@ -51,4 +54,23 @@ func ReadContent(uxBlocks uxBlock.UxBlocks, importYamlPath string, workingDir st
 
 	uxBlocks.PrintInfo(styles.InfoLine(i18n.T(i18n.ImportYamlOk)))
 	return yamlContent, nil
+}
+
+func ReadContentFromStdin(uxBlocks uxBlock.UxBlocks) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	size, err := io.Copy(buf, os.Stdin)
+	if err != nil {
+		return nil, fmt.Errorf("copying from stdin failed: %w", err)
+	}
+
+	if size == 0 {
+		return nil, errors.New(i18n.T(i18n.ImportYamlEmpty))
+	}
+
+	if size > 100*1024 {
+		return nil, errors.New(i18n.T(i18n.ImportYamlTooLarge))
+	}
+
+	uxBlocks.PrintInfo(styles.InfoLine(i18n.T(i18n.ImportYamlOk)))
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [X] Improvement
- [ ] Other

#### Description (required)

Allow reading yaml content from stdin in import commands. Also fix flag `workingDie` -> `workingDir`.