### PR TITLE
fix(serviceDeploy.go): i18n flag description

### DIFF
--- a/src/cmd/serviceDeploy.go
+++ b/src/cmd/serviceDeploy.go
@@ -31,7 +31,7 @@ func serviceDeployCmd() *cmdBuilder.Cmd {
 		StringFlag("versionName", "", i18n.T(i18n.BuildVersionName)).
 		StringFlag("zeropsYamlPath", "", i18n.T(i18n.ZeropsYamlLocation)).
 		StringFlag("setup", "", i18n.T(i18n.ZeropsYamlSetup)).
-		BoolFlag("deployGitFolder", false, i18n.T(i18n.ZeropsYamlLocation)).
+		BoolFlag("deployGitFolder", false, i18n.T(i18n.UploadGitFolder)).
 		HelpFlag(i18n.T(i18n.CmdHelpServiceDeploy)).
 		LoggedUserRunFunc(func(ctx context.Context, cmdData *cmdBuilder.LoggedUserCmdData) error {
 			uxBlocks := cmdData.UxBlocks


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Other

#### Description (required)

Wrong i18n key used in serviceDeploy.go
```
BoolFlag("deployGitFolder", false, i18n.T(i18n.ZeropsYamlLocation))

// Should be:
BoolFlag("deployGitFolder", false, i18n.T(i18n.UploadGitFolder))
```

in ``i18n.go`` for context
```
ZeropsYamlLocation:    "Sets a custom path to the zerops.yml file relative to the working directory. By default zCLI\nlooks for zerops.yml in the working directory."
UploadGitFolder:       "If set, zCLI the .git folder is also uploaded. By default, the .git folder is ignored."
```

#### Related issues & labels (optional)

- Closes #189 

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
