### PR TITLE
fix (``servicePush.go``): push without a flag provided

### DIFF
--- a/src/cmd/servicePush.go
+++ b/src/cmd/servicePush.go
@@ -25,6 +25,7 @@ func servicePushCmd() *cmdBuilder.Cmd {
 		Short(i18n.T(i18n.CmdDescPush)).
 		Long(i18n.T(i18n.CmdDescPushLong)).
 		ScopeLevel(scope.Service).
+		Arg(scope.ServiceArgName, cmdBuilder.OptionalArg()).
 		StringFlag("workingDir", "./", i18n.T(i18n.BuildWorkingDir)).
 		StringFlag("archiveFilePath", "", i18n.T(i18n.BuildArchiveFilePath)).
 		StringFlag("versionName", "", i18n.T(i18n.BuildVersionName)).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Other

#### Description 

The current usage for ``zcli push --serviceId`` is ``zcli push --serviceId z3eHIXPjT0iKAIZATAqg4g`` 
which pushes the code to the service which then gets built and deployed

was required to implement ``zcli push z3eHIXPjT0iKAIZATAqg4g`` without a flag 

made both cases work 
1) ``zcli push --serviceId z3eHIXPjT0iKAIZATAqg4g``

2) ``zcli push z3eHIXPjT0iKAIZATAqg4g``

used references and implementation from ``zcli vpn up`` in ``vpnUp.go``

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)


<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
