### PR TITLE
Fixed panic in logs with timestamp without milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.37] - 2025-02-27
+
+### Fixed
+- `service logs --messageType=WEBSERVER` should no longer panic
+
 ## [v1.0.36] - 2025-02-26
 
 ### Improved

--- a/src/serviceLogs/handler_formatByRfc.go
+++ b/src/serviceLogs/handler_formatByRfc.go
@@ -51,8 +51,10 @@ func fixTimestamp(timestamp string) string {
 		return timestamp
 	}
 	splitVal := strings.Split(timestamp, ".")
-	millis := strings.Split(splitVal[1], "Z")[0]
-
+	millis := ""
+	if len(splitVal) == 2 {
+		millis = strings.Split(splitVal[1], "Z")[0]
+	}
 	for len(millis) < 6 {
 		millis += "0"
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Other

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Fixed panic in logs with timestamp without milliseconds

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
