### PR TITLE
chore: bump go version to 1.24 & update golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,9 +32,7 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - execinquery
     - exhaustive
-    - exportloopref
     - forcetypeassert
     - ginkgolinter
     - gocheckcompilerdirectives
@@ -76,7 +74,7 @@ linters:
     - staticcheck
     - tagalign
     - tagliatelle
-    - tenv
+    - usetesting
     - testableexamples
     - testifylint
     - thelper

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ define helpMessage
 possible values:
 	test
  	lint
- 	build-for-windows-amd
- 	build-for-linux-amd
- 	build-for-darwin-arm
+ 	windows-amd
+ 	linux-amd
+ 	darwin-arm
 endef
 export helpMessage
 
@@ -22,11 +22,11 @@ lint:
 	GOOS=linux GOARCH=amd64 gomodrun golangci-lint run  ./cmd/... ./src/... --verbose
 	GOOS=windows GOARCH=amd64 gomodrun golangci-lint run  ./cmd/... ./src/... --verbose
 
-build-for-windows-amd:
+windows-amd:
 	 GOOS=windows GOARCH=amd64 go build -o bin/zcli.exe cmd/zcli/main.go
 
-build-for-linux-amd:
-	 GOOS=linux GOARCH=amd64 go build -o bin/zcli cmd/zcli/main.go
+linux-amd:
+	 GOOS=linux GOARCH=amd64 go build -o bin/zcli.linux cmd/zcli/main.go
 
-build-for-darwin-arm:
-	 GOOS=darwin GOARCH=arm64 go build -o bin/zcli cmd/zcli/main.go
+darwin-arm:
+	 GOOS=darwin GOARCH=arm64 go build -o bin/zcli.darwin cmd/zcli/main.go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zeropsio/zcli
 
-go 1.23
+go 1.24
 
 require github.com/zeropsio/zerops-go v1.0.10
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -20,4 +20,4 @@ echo "GOBIN=${GOBIN}"
 rm -rf tmp
 
 # https://github.com/golangci/golangci-lint#go Please, do not installDaemon golangci-lint by go get
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$GOBIN" v1.60.3
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$GOBIN" v1.64.7


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [ ] Fix
- [ ] Improvement
- [x] Other

#### Description (required)

chore: bump go version to 1.24 & update golangci-lint

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number  -->

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
