### PR TITLE
fix: print logs to stdout when not in terminal mode

### DIFF
--- a/src/uxHelpers/spinner.go
+++ b/src/uxHelpers/spinner.go
@@ -3,12 +3,14 @@ package uxHelpers
 import (
 	"context"
 	"io"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/zeropsio/zcli/src/generic"
 	"github.com/zeropsio/zcli/src/optional"
+	"github.com/zeropsio/zcli/src/terminal"
 	"github.com/zeropsio/zerops-go/dto/output"
 
 	"github.com/zeropsio/zcli/src/i18n"
@@ -82,7 +84,10 @@ type Process struct {
 	spinner             *uxBlock.Spinner
 }
 
-func (p *Process) LogView() io.WriteCloser {
+func (p *Process) LogView() io.Writer {
+	if !terminal.IsTerminal() {
+		return os.Stdout
+	}
 	return p.spinner.LogView()
 }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Other

#### Description (required)

print logs to stdout when not in terminal mode

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number  -->

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
