### PR TITLE
Added verbose flag to push command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.40] - 2025-03-27
+
+### Added
+- `--verbose` (shorthand `-v`) flag to `deploy` and `push` commands to log additional data do zcli debug log file
+
 ## [v1.0.39] - 2025-03-25
 
 ### Fixed

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zeropsio/zerops-go v1.0.10 h1:42zD02HQVKFu8Fc7NC+TtOaSdIIGdzl3Wm1XpR/Brao=
-github.com/zeropsio/zerops-go v1.0.10/go.mod h1:Nuqf1xWt53IRLyVoXgR4hF4ICc9jlfOfQgnN3ZhJR3E=
 github.com/zeropsio/zerops-go v1.0.11 h1:fEghFiEX32pR6LHmshfga/p+oT3Tv+k/JQ6lRLXQLvY=
 github.com/zeropsio/zerops-go v1.0.11/go.mod h1:Nuqf1xWt53IRLyVoXgR4hF4ICc9jlfOfQgnN3ZhJR3E=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/archiveClient/handler.go
+++ b/src/archiveClient/handler.go
@@ -1,5 +1,9 @@
 package archiveClient
 
+import (
+	"github.com/zeropsio/zcli/src/logger"
+)
+
 const (
 	WorkspaceAll    = "all"
 	WorkspaceStaged = "staged"
@@ -7,6 +11,8 @@ const (
 )
 
 type Config struct {
+	Logger             logger.Logger
+	Verbose            bool
 	DeployGitFolder    bool
 	PushWorkspaceState string
 }

--- a/src/archiveClient/handler_archiveGitFiles.go
+++ b/src/archiveClient/handler_archiveGitFiles.go
@@ -38,10 +38,16 @@ func (h *Handler) ArchiveGitFiles(ctx context.Context, workingDir string, writer
 }
 
 func (h *Handler) getRootDir(ctx context.Context, workingDir string) (string, error) {
+	if h.config.Verbose {
+		h.config.Logger.Info("git rev-parse --show-toplevel")
+	}
 	out := &strings.Builder{}
 	cmd := cmdRunner.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
 	cmd.Dir = workingDir
 	cmd.Stdout = out
+	if h.config.Verbose {
+		cmd.Stderr = h.config.Logger
+	}
 	if err := cmd.Run(); err != nil {
 		return "", err
 	}
@@ -50,7 +56,7 @@ func (h *Handler) getRootDir(ctx context.Context, workingDir string) (string, er
 
 // createSimpleArchive creates an archive without the .git directory
 func (h *Handler) createSimpleArchive(ctx context.Context, workingDir string, writer io.Writer) error {
-	archiver := newGitArchiver(workingDir, h.config.PushWorkspaceState)
+	archiver := newGitArchiver(workingDir, h.config.PushWorkspaceState, h.config.Verbose, h.config.Logger)
 	if err := archiver.initialize(ctx); err != nil {
 		return err
 	}

--- a/src/cmd/serviceDeploy.go
+++ b/src/cmd/serviceDeploy.go
@@ -28,12 +28,15 @@ func serviceDeployCmd() *cmdBuilder.Cmd {
 		StringFlag("versionName", "", i18n.T(i18n.BuildVersionName)).
 		StringFlag("zeropsYamlPath", "", i18n.T(i18n.ZeropsYamlLocation)).
 		StringFlag("setup", "", i18n.T(i18n.ZeropsYamlSetup)).
+		BoolFlag("verbose", false, i18n.T(i18n.VerboseFlag), cmdBuilder.ShortHand("v")).
 		BoolFlag("deployGitFolder", false, i18n.T(i18n.UploadGitFolder), cmdBuilder.ShortHand("g")).
 		HelpFlag(i18n.T(i18n.CmdHelpServiceDeploy)).
 		LoggedUserRunFunc(func(ctx context.Context, cmdData *cmdBuilder.LoggedUserCmdData) error {
 			uxBlocks := cmdData.UxBlocks
 
 			arch := archiveClient.New(archiveClient.Config{
+				Logger:          uxBlocks.GetDebugFileLogger(),
+				Verbose:         cmdData.Params.GetBool("verbose"),
 				DeployGitFolder: cmdData.Params.GetBool("deployGitFolder"),
 			})
 

--- a/src/cmd/servicePush.go
+++ b/src/cmd/servicePush.go
@@ -32,6 +32,7 @@ func servicePushCmd() *cmdBuilder.Cmd {
 		StringFlag("versionName", "", i18n.T(i18n.BuildVersionName)).
 		StringFlag("zeropsYamlPath", "", i18n.T(i18n.ZeropsYamlLocation)).
 		StringFlag("setup", "", i18n.T(i18n.ZeropsYamlSetup)).
+		BoolFlag("verbose", false, i18n.T(i18n.VerboseFlag), cmdBuilder.ShortHand("v")).
 		BoolFlag("deployGitFolder", false, i18n.T(i18n.UploadGitFolder), cmdBuilder.ShortHand("g")).
 		StringFlag("workspaceState", archiveClient.WorkspaceAll, i18n.T(i18n.PushWorkspaceState), cmdBuilder.ShortHand("w")).
 		BoolFlag("disableLogs", false, "disable logs").
@@ -40,6 +41,8 @@ func servicePushCmd() *cmdBuilder.Cmd {
 			uxBlocks := cmdData.UxBlocks
 
 			arch := archiveClient.New(archiveClient.Config{
+				Logger:             uxBlocks.GetDebugFileLogger(),
+				Verbose:            cmdData.Params.GetBool("verbose"),
 				DeployGitFolder:    cmdData.Params.GetBool("deployGitFolder"),
 				PushWorkspaceState: cmdData.Params.GetString("workspaceState"),
 			})

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -248,6 +248,7 @@ at https://docs.zerops.io/references/cli for further details.`,
 	ProjectIdFlag:         "If you have access to more than one project, you must specify the project ID for which the\ncommand is to be executed.",
 	VpnAutoDisconnectFlag: "If set, zCLI will automatically disconnect from the VPN if it is already connected.",
 	VpnMtuFlag:            "If set, Wireguard interface will use this value for MTU. If VPN is not working, try a lower value.",
+	VerboseFlag:           "If set, additional data will be logged to the zcli debug log file.",
 	ZeropsYamlSetup:       "Choose setup to be used from zerops.yml.",
 	DisableLogs:           "Disable log output.",
 

--- a/src/i18n/i18n.go
+++ b/src/i18n/i18n.go
@@ -230,6 +230,7 @@ const (
 	ProjectIdFlag         = "ProjectIdFlag"
 	VpnAutoDisconnectFlag = "VpnAutoDisconnectFlag"
 	VpnMtuFlag            = "VpnMtuFlag"
+	VerboseFlag           = "VerboseFlag"
 	ZeropsYamlSetup       = "ZeropsYamlSetup"
 	DisableLogs           = "DisableLogs"
 

--- a/src/logger/handler.go
+++ b/src/logger/handler.go
@@ -92,3 +92,7 @@ func (h *Handler) Debug(a ...interface{}) {
 func (h *Handler) Debugf(format string, a ...interface{}) {
 	h.logrus.Debugf(format, a...)
 }
+
+func (h *Handler) Write(p []byte) (n int, err error) {
+	return h.logrus.Writer().Write(p)
+}

--- a/src/logger/interface.go
+++ b/src/logger/interface.go
@@ -1,6 +1,7 @@
 package logger
 
 type Logger interface {
+	Write(p []byte) (n int, err error)
 	Info(...interface{})
 	Infof(string, ...interface{})
 	Warning(a ...interface{})

--- a/src/uxBlock/blocks.go
+++ b/src/uxBlock/blocks.go
@@ -11,6 +11,8 @@ import (
 //go:generate go run --mod=mod github.com/golang/mock/mockgen -source=$GOFILE -destination=$PWD/mocks/$GOFILE -package=mocks
 
 type UxBlocks interface {
+	GetOutputLogger() logger.Logger
+	GetDebugFileLogger() logger.Logger
 	LogDebug(message string)
 	PrintInfo(line styles.Line)
 	PrintWarning(line styles.Line)

--- a/src/uxBlock/logs.go
+++ b/src/uxBlock/logs.go
@@ -1,6 +1,17 @@
 package uxBlock
 
-import "github.com/zeropsio/zcli/src/uxBlock/styles"
+import (
+	"github.com/zeropsio/zcli/src/logger"
+	"github.com/zeropsio/zcli/src/uxBlock/styles"
+)
+
+func (b *Blocks) GetOutputLogger() logger.Logger {
+	return b.outputLogger
+}
+
+func (b *Blocks) GetDebugFileLogger() logger.Logger {
+	return b.debugFileLogger
+}
 
 func (b *Blocks) LogDebug(message string) {
 	b.debugFileLogger.Debug(message)

--- a/src/uxBlock/mocks/blocks.go
+++ b/src/uxBlock/mocks/blocks.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	logger "github.com/zeropsio/zcli/src/logger"
 	uxBlock "github.com/zeropsio/zcli/src/uxBlock"
 	styles "github.com/zeropsio/zcli/src/uxBlock/styles"
 )
@@ -34,6 +35,34 @@ func NewMockUxBlocks(ctrl *gomock.Controller) *MockUxBlocks {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUxBlocks) EXPECT() *MockUxBlocksMockRecorder {
 	return m.recorder
+}
+
+// GetDebugFileLogger mocks base method.
+func (m *MockUxBlocks) GetDebugFileLogger() logger.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDebugFileLogger")
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// GetDebugFileLogger indicates an expected call of GetDebugFileLogger.
+func (mr *MockUxBlocksMockRecorder) GetDebugFileLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDebugFileLogger", reflect.TypeOf((*MockUxBlocks)(nil).GetDebugFileLogger))
+}
+
+// GetOutputLogger mocks base method.
+func (m *MockUxBlocks) GetOutputLogger() logger.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOutputLogger")
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// GetOutputLogger indicates an expected call of GetOutputLogger.
+func (mr *MockUxBlocksMockRecorder) GetOutputLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutputLogger", reflect.TypeOf((*MockUxBlocks)(nil).GetOutputLogger))
 }
 
 // LogDebug mocks base method.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [ ] Fix
- [x] Improvement
- [ ] Release
- [ ] Other

#### Description (required)

## [v1.0.40] - 2025-03-27

### Added
- `--verbose` (shorthand `-v`) flag to `deploy` and `push` commands to log additional data do zcli debug log file
