### PR TITLE
Fix push command with workspace state set to all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.41] - 2025-03-29
+
+### Fixed
+- `--workspaceState` flag should now work correctly if set to `all`, but the repository has no changes
+
 ## [v1.0.40] - 2025-03-27
 
 ### Added

--- a/src/archiveClient/handler_gitArchiver.go
+++ b/src/archiveClient/handler_gitArchiver.go
@@ -67,10 +67,18 @@ func (h *gitArchiver) initialize(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
+		// `git stash create` returns nothing if there are no changes and user forgot to use WorkspaceClean, in such case, use HEAD
 		h.commit = commit
+		if h.commit == "" {
+			h.commit = "HEAD"
+		}
 	case WorkspaceClean:
 		// TODO(ms): add option for user to specify commit or tag, instead of forcing HEAD
 		h.commit = "HEAD"
+	}
+	if h.verbose {
+		h.logger.Info("Using git commit: " + h.commit)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Release
- [ ] Other

#### Description (required)

## [v1.0.41] - 2025-03-29

### Fixed
- `--workspaceState` flag should now work correctly if set to `all`, but the repository has no changes
