### PR TITLE
feat: authenticate via present ZEROPS_TOKEN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ curl -L https://zerops.io/zcli/install.sh | sh
 
 - Clone this repository
 - `cd zcli` into the root of the cloned repository and run `nix develop`.
-- Run `nix build` to build the binary / execuetable of zCli.
-- zCLI's binary / execuetable will be present in `./result/bin/zcli`.
+- Run `nix build` to build the binary / executable of zCLI.
+- zCLI's binary / executable will be present in `./result/bin/zcli`.
 
 Currently, the zCLI is distributed for Linux (x86 & x64 architecture), macOS (x64 & M1 architecture) and Windows (x64 architecture).
 

--- a/install.ps1
+++ b/install.ps1
@@ -40,6 +40,6 @@ if (!(";${Path};".ToLower() -like "*;${BinDir};*".ToLower())) {
 }
 
 Write-Output ""
-Write-Output "ZCli was installed successfully to ${ZcliExe}"
+Write-Output "zCLI was installed successfully to ${ZcliExe}"
 Write-Output "Run 'zcli --help' to get started"
 Write-Output "Stuck? Join our Discord https://discord.com/invite/WDvCZ54"

--- a/src/cmdBuilder/createRunFunc.go
+++ b/src/cmdBuilder/createRunFunc.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/zeropsio/zcli/src/cliStorage"
+	"github.com/zeropsio/zcli/src/constants"
 	"github.com/zeropsio/zcli/src/entity"
 	"github.com/zeropsio/zcli/src/flagParams"
 	"github.com/zeropsio/zcli/src/i18n"
@@ -87,6 +89,9 @@ func createCmdRunFunc(
 
 		token := storedData.Token
 		if token == "" {
+			token = os.Getenv(constants.CliTokenEnvVar)
+		}
+		if token == "" {
 			if cmd.guestRunFunc != nil {
 				return cmd.guestRunFunc(ctx, guestCmdData)
 			}
@@ -103,7 +108,11 @@ func createCmdRunFunc(
 			VpnKeys:      storedData.VpnKeys,
 		}
 
-		cmdData.RestApiClient = zeropsRestApiClient.NewAuthorizedClient(token, "https://"+storedData.RegionData.Address)
+		host := storedData.RegionData.Address
+		if host == "" {
+			host = constants.DefaultRegion
+		}
+		cmdData.RestApiClient = zeropsRestApiClient.NewAuthorizedClient(token, "https://"+host)
 
 		if cmd.scopeLevel != nil {
 			if err := cmd.scopeLevel.LoadSelectedScope(ctx, cmd, cmdData); err != nil {

--- a/src/constants/zerops.go
+++ b/src/constants/zerops.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	DefaultRegionUrl        = "https://api.app-prg1.zerops.io/api/rest/public/region/zcli"
+	DefaultRegion           = "api.app-prg1.zerops.io"
 	ZeropsDir               = "zerops"
 	ZeropsLogFile           = "zerops.log"
 	WgConfigFile            = "zerops.conf"
@@ -24,6 +25,7 @@ const (
 	CliLogFilePathEnvVar    = "ZEROPS_CLI_LOG_FILE_PATH"
 	CliWgConfigPathEnvVar   = "ZEROPS_WG_CONFIG_FILE_PATH"
 	CliTerminalMode         = "ZEROPS_CLI_TERMINAL_MODE"
+	CliTokenEnvVar          = "ZEROPS_TOKEN" //nolint:gosec
 )
 
 type pathReceiver func(fileMode os.FileMode) (path string, err error)

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -4,13 +4,21 @@ import "fmt"
 
 var en = map[string]string{
 	// root
-	GuestWelcome: `Welcome to zCli by Zerops!
+	GuestWelcome: `Welcome to zCLI by Zerops!
 
 To unlock the full potential of zCLI, you need to log in using your Zerops account.
 Logging in enables you to access various features and interact with Zerops services seamlessly.
 
-To log in, simply use the following command: zcli login <your_token>
+To log in, use the login command with your authentication token:
+zcli login <your_token>
+
+Alternatively, you can use the ZEROPS_TOKEN environment variable to authenticate:
+export ZEROPS_TOKEN="<your_token>"
+
+Note: The stored authentication data created by the login command takes precedence over the environment variable if both are present.
+
 Replace <your_token> with the authentication token generated from your Zerops account.
+
 Once logged in, you'll be able to manage projects, deploy applications, configure VPN,
 and much more directly from the command line interface.
 
@@ -22,7 +30,7 @@ and your %s.`,
 
 	// env
 	GlobalEnvVariables:        "Global Env Variables:",
-	CurrentlyUsedEnvVariables: "Curently used variables:",
+	CurrentlyUsedEnvVariables: "Currently used variables:",
 
 	// login
 	CmdHelpLogin:          "Help for the login command.",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [ ] Fix
- [x] Improvement
- [ ] Release
- [ ] Other

#### Description (required)

Allow authentication via present ZEROPS_TOKEN environment variable. Stored authentication data created by the `zcli login` takes precedence, if both authentication method are configured.

Only default region is supported with ZEROPS_TOKEN autentication, for now.
