### PR TITLE
fix: ZEROPS_TOKEN environment variable takes precedence over stored zcli

### DIFF
--- a/src/cmdBuilder/createRunFunc.go
+++ b/src/cmdBuilder/createRunFunc.go
@@ -88,8 +88,8 @@ func createCmdRunFunc(
 		storedData := cliStorage.Data()
 
 		token := storedData.Token
-		if token == "" {
-			token = os.Getenv(constants.CliTokenEnvVar)
+		if envToken, ok := os.LookupEnv(constants.CliTokenEnvVar); ok {
+			token = envToken
 		}
 		if token == "" {
 			if cmd.guestRunFunc != nil {

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -15,7 +15,7 @@ zcli login <your_token>
 Alternatively, you can use the ZEROPS_TOKEN environment variable to authenticate:
 export ZEROPS_TOKEN="<your_token>"
 
-Note: The stored authentication data created by the login command takes precedence over the environment variable if both are present.
+Note: The environment variable takes precedence over stored authentication data created by the login command, if both are present.
 
 Replace <your_token> with the authentication token generated from your Zerops account.
 


### PR DESCRIPTION
login data

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Release
- [ ] Other

#### Description (required)

ZEROPS_TOKEN environment variable should take precedence over stored zcli login data.