### PR TITLE
Improve push command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.54] - 2025-09-17
+
+### Fixed
+- `push` command now correctly validates content of a `--workspace-state` (`-w`) flag
+
+### Changed
+- `push` command now works with current directory, instead of always forcing root git directory
+
 ## [v1.0.53] - 2025-08-25
 
 ### Fixed

--- a/src/archiveClient/handler_archiveGitFiles.go
+++ b/src/archiveClient/handler_archiveGitFiles.go
@@ -38,9 +38,9 @@ func (h *Handler) ArchiveGitFiles(ctx context.Context, uxBlocks uxBlock.UxBlocks
 
 	// Start the appropriate archiving process based on config
 	if h.config.DeployGitFolder {
-		return h.createArchiveWithGitFolder(ctx, rootDir, gzipWriter)
+		return h.createArchiveWithGitFolder(ctx, rootDir, workingDir, gzipWriter)
 	}
-	return h.createSimpleArchive(ctx, rootDir, gzipWriter)
+	return h.createSimpleArchive(ctx, workingDir, gzipWriter)
 }
 
 func (h *Handler) getRootDir(ctx context.Context, workingDir string) (string, error) {
@@ -143,13 +143,13 @@ func (h *Handler) createSimpleArchive(ctx context.Context, workingDir string, wr
 }
 
 // createArchiveWithGitFolder creates an archive including the .git directory
-func (h *Handler) createArchiveWithGitFolder(ctx context.Context, workingDir string, writer io.Writer) error {
+func (h *Handler) createArchiveWithGitFolder(ctx context.Context, rootDir, workingDir string, writer io.Writer) error {
 	// Create a tar writer for our archive
 	tarWriter := tar.NewWriter(writer)
 	defer tarWriter.Close()
 
 	// First, add the .git directory to the tar
-	if err := h.addGitDirectory(workingDir, tarWriter); err != nil {
+	if err := h.addGitDirectory(rootDir, tarWriter); err != nil {
 		return err
 	}
 

--- a/src/cmd/servicePush.go
+++ b/src/cmd/servicePush.go
@@ -64,6 +64,9 @@ func servicePushCmd() *cmdBuilder.Cmd {
 			if cmdData.Params.IsSet("no-git") && (cmdData.Params.IsSet("deploy-git-folder") || cmdData.Params.IsSet("workspace-state")) {
 				uxBlocks.PrintWarning(styles.WarningLine("--no-git and --deploy-git-folder/--workspace-state are mutually exclusive, ignoring --deploy-git-folder/--workspace-state"))
 			}
+			if cmdData.Params.IsSet("workspace-state") && !gn.IsOneOf(cmdData.Params.GetString("workspace-state"), archiveClient.WorkspaceAll, archiveClient.WorkspaceClean, archiveClient.WorkspaceStaged) {
+				return errors.New("Invalid value for --workspace-state, please use one of: " + archiveClient.WorkspaceAll + ", " + archiveClient.WorkspaceClean + ", " + archiveClient.WorkspaceStaged)
+			}
 
 			configContent, err := yamlReader.ReadZeropsYamlContent(
 				uxBlocks,


### PR DESCRIPTION
## [v1.0.54] - 2025-09-17

### Fixed
- `push` command now correctly validates content of a `--workspace-state` (`-w`) flag

### Changed
- `push` command now works with current directory, instead of always forcing root git directory