### PR TITLE
Add --location flag to project create

### DIFF
--- a/src/cmd/projectCreate.go
+++ b/src/cmd/projectCreate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zeropsio/zcli/src/uxHelpers"
 	"github.com/zeropsio/zerops-go/types"
 	"github.com/zeropsio/zerops-go/types/enum"
+	"github.com/zeropsio/zerops-go/types/stringId"
 	"github.com/zeropsio/zerops-go/types/uuid"
 )
 
@@ -34,6 +35,7 @@ func projectCreateCmd() *cmdBuilder.Cmd {
 		StringFlag("mode", enumDefaultForFlag(enum.ProjectModeEnumLight), "Project mode"+enumValuesForFlag(enum.ProjectModeEnumAllPublic())).
 		StringFlag("env-isolation", "service", "Env isolation rule [service, none] for more info see docs https://docs.zerops.io/features/env-variables#isolation-modes").
 		StringFlag("ssh-isolation", "vpn", "SSH isolation rules, for more info see docs https://docs.zerops.io/references/ssh#ssh-access-control").
+		StringFlag("location", "eu-central", "Project location (e.g. eu-central, us-east)").
 		HelpFlag("Help for the project create command.").
 		LoggedUserRunFunc(func(ctx context.Context, cmdData *cmdBuilder.LoggedUserCmdData) error {
 			var err error
@@ -115,6 +117,7 @@ func projectCreateCmd() *cmdBuilder.Cmd {
 				Mode:         enum.ProjectModeEnum(mode),
 				SshIsolation: types.NewStringNull(cmdData.Params.GetString("ssh-isolation")),
 				EnvIsolation: types.NewStringNull(cmdData.Params.GetString("env-isolation")),
+				Location:     stringId.NewLocationIdNullFromString(cmdData.Params.GetString("location")),
 			})
 			if err != nil {
 				return err

--- a/src/cmd/projectCreate.go
+++ b/src/cmd/projectCreate.go
@@ -35,7 +35,7 @@ func projectCreateCmd() *cmdBuilder.Cmd {
 		StringFlag("mode", enumDefaultForFlag(enum.ProjectModeEnumLight), "Project mode"+enumValuesForFlag(enum.ProjectModeEnumAllPublic())).
 		StringFlag("env-isolation", "service", "Env isolation rule [service, none] for more info see docs https://docs.zerops.io/features/env-variables#isolation-modes").
 		StringFlag("ssh-isolation", "vpn", "SSH isolation rules, for more info see docs https://docs.zerops.io/references/ssh#ssh-access-control").
-		StringFlag("location", "eu-central", "Project location (e.g. eu-central, us-east)").
+		StringFlag("location", "", "Project location (e.g. us-east, defaults to eu-central)").
 		HelpFlag("Help for the project create command.").
 		LoggedUserRunFunc(func(ctx context.Context, cmdData *cmdBuilder.LoggedUserCmdData) error {
 			var err error

--- a/src/cmd/projectCreate.go
+++ b/src/cmd/projectCreate.go
@@ -110,15 +110,19 @@ func projectCreateCmd() *cmdBuilder.Cmd {
 				return errors.New("Must specify name with --name")
 			}
 
-			project, err := repository.PostProject(ctx, cmdData.RestApiClient, entity.PostProject{
+			postProject := entity.PostProject{
 				OrgId:        org.Id,
 				Name:         types.NewString(name),
 				Tags:         cmdData.Params.GetStringSlice("tags"),
 				Mode:         enum.ProjectModeEnum(mode),
 				SshIsolation: types.NewStringNull(cmdData.Params.GetString("ssh-isolation")),
 				EnvIsolation: types.NewStringNull(cmdData.Params.GetString("env-isolation")),
-				Location:     stringId.NewLocationIdNullFromString(cmdData.Params.GetString("location")),
-			})
+			}
+			if loc := cmdData.Params.GetString("location"); loc != "" {
+				postProject.Location = stringId.NewLocationIdNullFromString(loc)
+			}
+
+			project, err := repository.PostProject(ctx, cmdData.RestApiClient, postProject)
 			if err != nil {
 				return err
 			}

--- a/src/entity/project.go
+++ b/src/entity/project.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"github.com/zeropsio/zerops-go/types"
 	"github.com/zeropsio/zerops-go/types/enum"
+	"github.com/zeropsio/zerops-go/types/stringId"
 	"github.com/zeropsio/zerops-go/types/uuid"
 )
 
@@ -25,4 +26,5 @@ type PostProject struct {
 	Mode         enum.ProjectModeEnum
 	SshIsolation types.StringNull
 	EnvIsolation types.StringNull
+	Location     stringId.LocationIdNull
 }

--- a/src/entity/repository/project.go
+++ b/src/entity/repository/project.go
@@ -83,6 +83,7 @@ func PostProject(
 		TagList:      post.Tags,
 		SshIsolation: post.SshIsolation,
 		EnvIsolation: post.EnvIsolation,
+		Location:     post.Location,
 	}
 	if postBody.TagList == nil {
 		postBody.TagList = make(types.StringArray, 0)


### PR DESCRIPTION
## Summary
- Adds a `--location` flag to `zcli project create` so customers can pick the project location (e.g. `eu-central`, `us-east`).
- Defaults to `eu-central`.
- Wires the value through `entity.PostProject` → `body.PostProject.Location` (using `stringId.LocationIdNull`, already supported by zerops-go v1.0.18).

## Test plan
- [ ] `zcli project create --name foo --org-id <id>` creates a project in `eu-central` (default)
- [ ] `zcli project create --name foo --org-id <id> --location us-east` creates a project in `us-east`
- [ ] `--help` shows the new flag with description

🤖 Generated with [Claude Code](https://claude.com/claude-code)