### PR TITLE
Reapply: Use upload url from POST /app-version instead of direct PUT /app-version/{id}/upload

### DIFF
--- a/src/cmd/serviceDeploy.go
+++ b/src/cmd/serviceDeploy.go
@@ -151,7 +151,7 @@ func serviceDeployCmd() *cmdBuilder.Cmd {
 							writer.CloseWithError(err)
 						}()
 
-						if err := packageStream(ctx, cmdData.RestApiClient, appVersion.Id, finalReader); err != nil {
+						if err := packageStream(ctx, appVersion.UploadUrl, finalReader); err != nil {
 							// if an error occurred while packing the app, return that error
 							return err
 						}

--- a/src/cmd/servicePush.go
+++ b/src/cmd/servicePush.go
@@ -153,7 +153,7 @@ func servicePushCmd() *cmdBuilder.Cmd {
 							defer wg.Done()
 
 							// if an error occurred during upload, return it (it could be even auth error, before upload starts)
-							if err := packageStream(ctx, cmdData.RestApiClient, appVersion.Id, finalReader); err != nil {
+							if err := packageStream(ctx, appVersion.UploadUrl, finalReader); err != nil {
 								_ = reader.CloseWithError(err)
 								uploadErr = err // in case the reader is already closed with EOF, sometimes happened with timeouts
 							}

--- a/src/cmd/servicePushDeployShared.go
+++ b/src/cmd/servicePushDeployShared.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zeropsio/zerops-go/dto/output"
 	"github.com/zeropsio/zerops-go/errorCode"
 	"github.com/zeropsio/zerops-go/types"
-	"github.com/zeropsio/zerops-go/types/uuid"
 )
 
 func createAppVersion(
@@ -84,18 +83,22 @@ func openPackageFile(archiveFilePath string, workingDir string) (*os.File, error
 	return file, nil
 }
 
-func packageStream(ctx context.Context, restApiClient *zeropsRestApiClient.Handler, appVersionId uuid.AppVersionId, reader io.Reader) error {
-	// TODO(ms): content-type: application/octet-stream
-	upload, err := restApiClient.PutAppVersionUpload(ctx, path.AppVersionId{Id: appVersionId}, reader)
+func packageStream(ctx context.Context, uploadUrl types.String, reader io.Reader) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadUrl.Native(), reader)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to create upload HTTP request: PUT %s => %v", uploadUrl, err)
 	}
-	if _, err := upload.Output(); err != nil {
-		return err
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Errorf("failed to upload HTTP request: %v", err)
 	}
-	if upload.StatusCode() != http.StatusOK {
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusMultipleChoices {
 		return errors.New(i18n.T(i18n.PushDeployUploadPackageFailed))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This reverts commit a6270828a2926f50c77844bec04b5113abc613b4.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Release
- [ ] Other

#### Description (required)

Reapply uploading via returned url from POST /app-version. It now returns nest proxy with a new secure upload endpoint.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number  -->

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
