### PR TITLE
fix: remove dependency on postinstall script

### DIFF
--- a/tools/npm/package.json
+++ b/tools/npm/package.json
@@ -25,7 +25,6 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "node ./utils/install.js",
     "preuninstall": "node ./utils/uninstall.js"
   }
 }

--- a/tools/npm/utils/binary.js
+++ b/tools/npm/utils/binary.js
@@ -29,7 +29,7 @@ const run = () => {
 
 const install = () => {
   const binary = getBinary();
-  binary.install();
+  return binary.install();
 };
 
 const uninstall = () => {
@@ -37,8 +37,15 @@ const uninstall = () => {
   binary.uninstall();
 };
 
+const getBinaryPath = () => {
+  const { join } = require("path");
+  const platform_arch = getPlatform();
+  return join(__dirname, "bin", "bin", `zcli-${platform_arch}`);
+};
+
 module.exports = {
   install,
   run,
   uninstall,
+  getBinaryPath,
 };

--- a/tools/npm/utils/run.js
+++ b/tools/npm/utils/run.js
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
 
-const { run } = require("./binary");
-run();
+const { existsSync } = require("fs");
+const { run, install, getBinaryPath } = require("./binary");
+
+if (!existsSync(getBinaryPath())) {
+  process.stderr.write("binary not found downloading now...\n");
+  install()
+    .then(() => run())
+    .catch((err) => {
+      process.stderr.write(`download failed: ${err.message}\n`);
+      process.exit(1);
+    });
+} else {
+  run();
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Feature
- [x] Fix
- [ ] Improvement
- [ ] Release
- [ ] Other

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

fixes bun compatibility bun blocks postinstall scripts by default,
so the binary was never downloaded. this pr removes the dependency on postinstall script

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
