### PR TITLE
PR template revamp and create-pr skill

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!skills/
+!skills/**

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: create-pr
+description: Prepare a GitHub PR for the current branch using .github/PULL_REQUEST_TEMPLATE.md, with fitting labels. Uses `gh` when available; otherwise outputs the filled PR description and suggested labels for the user to apply manually. Use when the user asks to "create a PR", "open a pull request", "make a PR", etc.
+model: sonnet
+---
+
+# create-pr
+
+Prepare a PR against `main` for the current branch, filling in the project's PR template and picking fitting labels.
+
+Check whether `gh` is available (`command -v gh`). If yes, create the PR directly. If not, output the filled description and suggested labels for the user to apply manually on GitHub. Do not pressure the user to install `gh`.
+
+## Steps
+
+1. **Gather context** (parallel where possible):
+   - `git status` (no `-uall`)
+   - `git diff <base>...HEAD` to see the full set of changes on this branch (see step 2 for `<base>`)
+   - `git log <base>..HEAD --oneline` to see commits and their conventional-commit prefixes
+   - Check the branch is pushed and tracks a remote; if not, push with `-u` (only if `gh` will be used to create the PR)
+
+2. **Pick the base branch.** Default to `main`. Before continuing, look for signals the PR might actually target a feature branch:
+   - The current branch's upstream (`git rev-parse --abbrev-ref @{upstream}`) points to a non-main remote branch
+   - `git merge-base --is-ancestor main HEAD` fails (HEAD is not based on the current tip of main but on some other branch)
+   - The branch name suggests stacking (e.g. `feat/foo-part2` while `feat/foo-part1` exists)
+
+   If any of those is true, ask the user which base to target before proceeding. Otherwise confirm `main` in one short sentence and continue without a prompt. Use the chosen base everywhere `<base>` appears below and pass it to `gh pr create --base <base>`.
+
+3. **Verify before creating.** Check whether the branch touches Go code with `git diff --name-only <base>...HEAD | grep -E '\.go$|^go\.(mod|sum)$'`.
+
+   - If Go files changed, run `make test` (full Go test suite including in-process integration tests under `cmd/...`) then `make lint`. If either fails, stop, show the user the failure, and do not proceed to PR creation.
+   - If no Go files changed (docs, markdown, CI config, skills, etc.), skip both. State that explicitly in one short line so the user knows you skipped intentionally.
+
+   Use the actual results (or the explicit skip) in the Test plan section below - do not paraphrase or invent.
+
+4. **Determine Type** from the conventional-commit prefixes on the branch's commits:
+   - `feat` → feat (user-visible new behavior)
+   - `fix` → fix (bug fix)
+   - `refactor` → refactor (no behavior change)
+   - `docs` → docs (documentation only)
+   - `chore` → chore (tooling, deps, housekeeping)
+   - `ci` → ci (CI/CD pipeline)
+   - `test` → test (tests only)
+
+   If a branch mixes types (e.g. one `feat` plus a `test`), pick the dominant one - usually the highest in this priority order: feat > fix > refactor > docs > chore > ci > test.
+
+5. **Draft the PR title.** Format rules:
+   - **Sentence case, descriptive noun phrase.** Capitalize the first word, leave the rest lowercase unless it's a proper noun or technical identifier (e.g. `zcli`, `--check`). The title describes *what the PR is*, not what it does. Examples: `PR template revamp and create-pr skill`, `Race fix in version cache writer`, `--check flag for zcli upgrade`.
+   - **Under 70 characters.** Avoids truncation in GitHub list views.
+   - **No conventional-commit prefix.** Those belong on commits, not the title.
+   - **No trailing period.** Title is a phrase, not a sentence.
+   - **No backticks or markdown.** GitHub does not render markdown in titles; they appear literally.
+   - **No issue number in the title.** Use `Closes #N` in the Description instead.
+
+6. **Fill the PR body** from `.github/PULL_REQUEST_TEMPLATE.md`. Uncomment the chosen Type line(s), write Description, Test plan, Breaking changes. Drop the example block at the bottom. If the branch closes an issue, add `Closes #N` inside the Description (no need for a separate Closes section).
+
+7. **Map Type to labels** for `gh pr create --label`:
+   - feat → `enhancement`
+   - fix → `bug`
+   - refactor → `refactor`
+   - docs → `documentation`
+   - chore → `chore`
+   - ci → `ci`
+   - test → `test`
+   - Additionally add `dependencies` if commits touch `go.mod`/`go.sum`/`package.json`/`flake.nix`.
+
+8. **Create or output the PR**:
+
+   - **With `gh` available:** create the PR with `gh pr create`, passing labels via `--label`, body via HEREDOC. Example shape:
+
+     ```bash
+     gh pr create \
+       --title "Short human summary" \
+       --label feat-mapped-label \
+       --body "$(cat <<'EOF'
+     ## Type
+
+     **feat** - user-visible new behavior
+
+     ## Description
+
+     ...
+
+     ## Test plan
+
+     ...
+
+     ## Breaking changes
+
+     None.
+     EOF
+     )"
+     ```
+
+     Return the PR URL.
+
+   - **Without `gh`:** output the filled PR description in a fenced code block (so it can be copy-pasted into the GitHub "New PR" form), the suggested title on its own line, and the suggested labels as a comma-separated list. Don't try to push the branch on the user's behalf in this path; let the user handle the GitHub side.
+
+## Hard rules
+
+- NEVER append a `Co-Authored-By: Claude ...` trailer to anything (PR body, commits).
+- NEVER use `--no-verify`, `--no-gpg-sign`, or skip hooks.
+- NEVER force-push without explicit user request.
+- If `gh pr create` fails because labels don't exist on the repo, list current labels with `gh label list` and ask the user before creating new ones.
+- Don't fill in fake test results. If you didn't run the tests in this session, write what the submitter still needs to run, or ask the user what they ran.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,66 @@
-<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
+<!-- Thanks for the PR! -->
 
-#### What Type of Change is this?
+## Type
 
-- [ ] New Feature
-- [ ] Fix
-- [ ] Improvement
-- [ ] Release
-- [ ] Other
+<!-- Uncomment the line(s) that apply. Match the conventional-commit prefix on your commits. -->
 
-#### Description (required)
+<!-- **feat** - user-visible new behavior -->
+<!-- **fix** - bug fix -->
+<!-- **refactor** - no behavior change -->
+<!-- **docs** - documentation only -->
+<!-- **chore** - tooling, deps, housekeeping -->
+<!-- **ci** - CI/CD pipeline -->
+<!-- **test** - tests only -->
 
-<!-- Please describe the change you are proposing, and why -->
+## Description
 
-#### Related issues & labels (optional)
+<!-- What does this change, and why? Link any relevant context. -->
 
-- Closes #<!-- Add an issue number  -->
+## Test plan
 
-<!-- #### First-time contributor to Zerops Docs? -->
+<!-- How did you verify this? Commands run, platforms tested (macOS / Linux / Windows), notable edge cases. Paste output if useful. -->
 
-<!-- Join our Discord Server  -->
-<!-- https://discord.gg/xxzmJSDKPT -->
+## Breaking changes
+
+<!-- Removed/renamed flags, changed command output, changed exit codes, config format changes. Leave "None" if none. -->
+
+None.
+
+## Closes
+
+<!-- Optional. e.g. Closes #123 -->
+
+<!--
+Don't forget to apply labels via the GitHub sidebar. Available:
+bug, enhancement, refactor, documentation, chore, ci, test, dependencies,
+duplicate, good first issue, help wanted
+-->
+
+<!--
+=== Example (delete before submitting) ===
+
+## Type
+
+**feat** - user-visible new behavior
+
+## Description
+
+Adds `zcli upgrade --check` so users (and package managers) can detect whether
+a newer release is available without performing the upgrade itself. Exits 0 if
+up to date, non-zero with a structured message if an update exists.
+
+## Test plan
+
+- `go test ./src/cmd/... ./src/version/...` on macOS arm64
+- Manual: `zcli upgrade --check` against a stubbed API URL returning a higher
+  version, confirmed exit code 10 and the channel-aware hint
+- Manual: same with the API URL returning the current version, confirmed exit 0
+
+## Breaking changes
+
+None.
+
+## Closes
+
+Closes #142
+-->


### PR DESCRIPTION
## Type

**chore** - tooling, deps, housekeeping

## Description

Three related changes to improve the PR workflow in this repo:

- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): replaces the old change-type checklist with conventional-commit-aligned types (`feat`, `fix`, `refactor`, `docs`, `chore`, `ci`, `test`). Adds explicit **Test plan** and **Breaking changes** sections. Includes a label reminder (the GitHub Labels sidebar still has to be clicked manually, but the available set is listed). Drops the dead Discord block and the awkward inline-comment `Closes #` UX. A filled-out example sits at the bottom inside an HTML comment so it doesn't render in submitted PRs.
- **`.claude/.gitignore`**: carves out `skills/` so project-local Claude Code skills can be tracked in git while `settings.local.json` and other local-only files stay ignored.
- **`/create-pr` skill** (`.claude/skills/create-pr/SKILL.md`): a project skill that gathers branch context, picks the base branch (prompts if signals suggest a stacked PR), runs `make test`/`make lint` only when Go files changed, fills the template, maps Type to a repo label, and creates the PR via `gh` when available (falls back to printing the body + suggested labels otherwise). Pinned to sonnet.

Companion change made via `gh` (not in this diff): the repo label set was trimmed (removed `go`, `javascript`, `error handling`, `packages`, `invalid`, `not as planned`) and extended with `refactor`, `chore`, `ci`, `test` to mirror the template's Type list.

## Test plan

No Go code changed - `make test` and `make lint` skipped per the new skill's verify step. Manual verification:

- Confirmed `.claude/skills/create-pr/SKILL.md` is no longer ignored by git after the `.gitignore` exception
- Confirmed final label set via `gh label list`: 11 labels, each maps to either a PR Type or a triage signal
- Reviewed the rendered PR template (this PR's body is itself a real-world test of the new template)

## Breaking changes

None.