### PR TITLE
feat: add zcli update command with auto-update notification

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zeropsio/zcli/src/errorsx"
 	"github.com/zeropsio/zcli/src/i18n"
 	"github.com/zeropsio/zcli/src/printer"
+	"github.com/zeropsio/zcli/src/upgrade"
 	"github.com/zeropsio/zcli/src/uxBlock/styles"
 	"github.com/zeropsio/zcli/src/wg"
 	"github.com/zeropsio/zerops-go/errorCode"
@@ -26,6 +27,7 @@ func rootCmd() *cmdBuilder.Cmd {
 		AddChildrenCmd(loginCmd()).
 		AddChildrenCmd(logoutCmd()).
 		AddChildrenCmd(versionCmd()).
+		AddChildrenCmd(updateCmd()).
 		AddChildrenCmd(upgradeCmd()).
 		AddChildrenCmd(scopeCmd()).
 		AddChildrenCmd(projectCmd()).
@@ -41,7 +43,11 @@ func rootCmd() *cmdBuilder.Cmd {
 				printer.EmptyLine,
 			)
 
-			// print the default command help
+			go upgrade.RefreshCacheIfStale(ctx)
+			if warning := upgrade.NewUpgrader().MismatchWarning(); warning != "" {
+				cmdData.Stdout.Println(warning)
+			}
+
 			cmdData.PrintHelp()
 
 			return nil
@@ -93,7 +99,11 @@ func rootCmd() *cmdBuilder.Cmd {
 				printer.EmptyLine,
 			)
 
-			// print the default command help
+			go upgrade.RefreshCacheIfStale(ctx)
+			if warning := upgrade.NewUpgrader().MismatchWarning(); warning != "" {
+				cmdData.Stdout.Println(warning)
+			}
+
 			cmdData.PrintHelp()
 
 			return nil

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zeropsio/zcli/src/cmdBuilder"
+	"github.com/zeropsio/zcli/src/i18n"
+	"github.com/zeropsio/zcli/src/upgrade"
+	"github.com/zeropsio/zcli/src/uxBlock/models/prompt"
+	"github.com/zeropsio/zcli/src/uxBlock/styles"
+	"github.com/zeropsio/zcli/src/uxHelpers"
+)
+
+func updateCmd() *cmdBuilder.Cmd {
+	return cmdBuilder.NewCmd().
+		Use("update").
+		Short(i18n.T(i18n.CmdDescUpdate)).
+		HelpFlag(i18n.T(i18n.CmdHelpUpdate)).
+		BoolFlag("yes", false, i18n.T(i18n.UpdateYesFlag)).
+		GuestRunFunc(func(ctx context.Context, cmdData *cmdBuilder.GuestCmdData) error {
+			upgrader := upgrade.NewUpgrader()
+			yes := cmdData.Params.GetBool("yes")
+
+			plan, err := upgrader.PlanUpgrade(ctx, upgrade.Options{})
+			if err != nil {
+				return err
+			}
+
+			if err := upgrader.RequireSelfUpdatable(); err != nil {
+				return err
+			}
+
+			if err := plan.RequireSelfUpgradable(); err != nil {
+				return err
+			}
+
+			if !plan.NeedsUpgrade() {
+				cmdData.Stdout.Printf(
+					i18n.T(i18n.UpdateAlreadyUpToDate),
+					plan.Current(),
+				)
+				return nil
+			}
+
+			cmdData.Stdout.Printf(
+				i18n.T(i18n.UpdateVersionInfo),
+				plan.Current(),
+				plan.Target(),
+			)
+
+			if !yes {
+				confirmed, err := uxHelpers.YesNoPrompt(
+					ctx,
+					i18n.T(i18n.UpdatePrompt),
+					prompt.WithDialogBoxStyle(styles.DialogBox()),
+				)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					cmdData.Stdout.Println(i18n.T(i18n.UpdateAborted))
+					return nil
+				}
+			}
+
+			return uxHelpers.ProcessCheckWithSpinner(
+				ctx,
+				cmdData.UxBlocks,
+				[]uxHelpers.Process{{
+					F: func(ctx context.Context, _ *uxHelpers.Process) error {
+						return upgrader.Apply(ctx, plan)
+					},
+					RunningMessage:      fmt.Sprintf(i18n.T(i18n.UpdateDownloading), plan.Target()),
+					ErrorMessageMessage: fmt.Sprintf(i18n.T(i18n.UpdateFailed), plan.Target()),
+					SuccessMessage:      fmt.Sprintf(i18n.T(i18n.UpdateSuccess), plan.Target()),
+				}},
+			)
+		})
+}

--- a/src/i18n/en.go
+++ b/src/i18n/en.go
@@ -198,6 +198,18 @@ and your %s.`,
 	CmdHelpVersion: "Help for the version command.",
 	CmdDescVersion: "Shows the current zCLI version",
 
+	// update
+	CmdHelpUpdate:         "Help for the update command.",
+	CmdDescUpdate:         "Check for updates and update zcli to the latest release.",
+	UpdateYesFlag:         "Skip the confirmation prompt.",
+	UpdateAlreadyUpToDate: "zcli is already up to date (%s).\n",
+	UpdateVersionInfo:     "Current: %s\nLatest:  %s\n",
+	UpdatePrompt:          "Update?",
+	UpdateAborted:         "Aborted.\n",
+	UpdateDownloading:     "Downloading and installing %s",
+	UpdateFailed:          "Update to %s failed",
+	UpdateSuccess:         "Updated to %s. Run `zcli version` to confirm.",
+
 	// support
 	CmdHelpSupport: "Help for the support command.",
 	CmdDescSupport: "How to contact Zerops support for assistance",

--- a/src/i18n/i18n.go
+++ b/src/i18n/i18n.go
@@ -175,6 +175,18 @@ const (
 	CmdHelpVersion = "CmdHelpVersion"
 	CmdDescVersion = "CmdDescVersion"
 
+	// update
+	CmdHelpUpdate        = "CmdHelpUpdate"
+	CmdDescUpdate        = "CmdDescUpdate"
+	UpdateYesFlag        = "UpdateYesFlag"
+	UpdateAlreadyUpToDate = "UpdateAlreadyUpToDate"
+	UpdateVersionInfo    = "UpdateVersionInfo"
+	UpdatePrompt         = "UpdatePrompt"
+	UpdateAborted        = "UpdateAborted"
+	UpdateDownloading    = "UpdateDownloading"
+	UpdateFailed         = "UpdateFailed"
+	UpdateSuccess        = "UpdateSuccess"
+
 	// support
 	CmdHelpSupport = "CmdHelpSupport"
 	CmdDescSupport = "CmdDescSupport"


### PR DESCRIPTION
Implements the feature requested in #185 — a simpler \zcli update\ command that checks for updates and prompts to install, plus an auto-update notification when running \zcli\.

### New: \src/cmd/update.go\
- Checks current vs latest version
- Shows \Current: vX.Y.Z / Latest: vA.B.C\
- Prompts y/n to update (ohmyzsh-style)
- Downloads + applies the binary with a spinner
- Supports \--yes\ flag to skip confirmation
- Handles install method detection and old pre-v1.1.0 releases

### Modified: \src/cmd/root.go\
- Registered \updateCmd()\ between \ersion\ and \upgrade\
- Auto-update check: background cache refresh + non-blocking MismatchWarning in both GuestRunFunc and LoggedUserRunFunc

### Modified: \src/i18n/i18n.go\ + \src/i18n/en.go\
Added i18n constants and English translations.

Closes #185