### PR TITLE
chore: bump zerops-go to v1.0.19 and migrate from /search endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,9 @@ module github.com/zeropsio/zcli
 
 go 1.26
 
-require github.com/zeropsio/zerops-go v1.0.18
+require github.com/zeropsio/zerops-go v1.0.19
+
+replace github.com/zeropsio/zerops-go => ../zerops-go
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zeropsio/zerops-go v1.0.18 h1:UZMbyfg1ZEgLmDeBTTvyfH5v02juf6TMjAL0ZoTWGgA=
-github.com/zeropsio/zerops-go v1.0.18/go.mod h1:SY4o+4jAIrsDTwWACooogf1OyY1jNK8NqWBe9KFcjAA=
+github.com/zeropsio/zerops-go v1.0.19 h1:C4A96tc4pqlPHfv9ebn3O/8ggE3+FOWXLFomkfovcpI=
+github.com/zeropsio/zerops-go v1.0.19/go.mod h1:SY4o+4jAIrsDTwWACooogf1OyY1jNK8NqWBe9KFcjAA=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/src/cmd/projectList_integration_test.go
+++ b/src/cmd/projectList_integration_test.go
@@ -8,11 +8,13 @@ import (
 )
 
 // TestProjectListCommand checks that `zcli project list` walks GetUserInfo →
-// org filtering (ACTIVE only) → PostProjectSearch and renders a table that
+// org filtering (ACTIVE only) → GetClientProject and renders a table that
 // contains the project id, name, and org name.
 func TestProjectListCommand(t *testing.T) {
 	f := newFixture(t)
 	f.SeedLogin("test-token")
+
+	orgId := "00000000-0000-0000-0000-0000000000aa"
 
 	// GetAllOrgs reads UserAuthorize.clientUserList. Only ACTIVE clients are
 	// queried for projects.
@@ -21,24 +23,21 @@ func TestProjectListCommand(t *testing.T) {
 		"fullName": "Test User",
 		"clientUserList": []map[string]any{{
 			"id":       "00000000-0000-0000-0000-000000000001",
-			"clientId": "00000000-0000-0000-0000-0000000000aa",
+			"clientId": orgId,
 			"userId":   "00000000-0000-0000-0000-000000000002",
 			"status":   "ACTIVE",
 			"roleCode": "ADMIN",
 			"client": map[string]any{
-				"id":          "00000000-0000-0000-0000-0000000000aa",
+				"id":          orgId,
 				"accountName": "Acme Org",
 			},
 		}},
 	})
 
-	f.HandleJSON("/api/rest/public/project/search", 200, map[string]any{
-		"limit":     50,
-		"offset":    0,
-		"totalHits": 1,
-		"items": []map[string]any{{
+	f.HandleJSON("/api/rest/public/client/"+orgId+"/project", 200, map[string]any{
+		"list": []map[string]any{{
 			"id":          "00000000-0000-0000-0000-0000000000bb",
-			"clientId":    "00000000-0000-0000-0000-0000000000aa",
+			"clientId":    orgId,
 			"name":        "demo-project",
 			"mode":        "LIGHT",
 			"status":      "ACTIVE",
@@ -47,6 +46,7 @@ func TestProjectListCommand(t *testing.T) {
 			"tagList":     []string{},
 			"description": nil,
 		}},
+		"totalCount": 1,
 	})
 
 	res := f.Run("project", "list")

--- a/src/cmd/serviceCreate.go
+++ b/src/cmd/serviceCreate.go
@@ -20,10 +20,9 @@ import (
 	"github.com/zeropsio/zcli/src/uxBlock/styles"
 	"github.com/zeropsio/zcli/src/uxHelpers"
 	"github.com/zeropsio/zcli/src/yamlReader"
-	"github.com/zeropsio/zerops-go/apiError"
+		"github.com/zeropsio/zerops-go/apiError"
 	"github.com/zeropsio/zerops-go/errorCode"
 	"github.com/zeropsio/zerops-go/types"
-	"github.com/zeropsio/zerops-go/types/enum"
 	"github.com/zeropsio/zerops-go/types/stringId"
 )
 
@@ -37,7 +36,7 @@ func serviceCreateCmd() *cmdBuilder.Cmd {
 		StringFlag("zerops-yaml-path", "", i18n.T(i18n.ZeropsYamlLocation)).
 		StringFlag("working-dir", "./", i18n.T(i18n.BuildWorkingDir)).
 		StringFlag("name", "", "Service name").
-		StringFlag("mode", enumDefaultForFlag(enum.ServiceStackModeEnumNonHa), "Service mode "+enumValuesForFlag(enum.ServiceStackModeEnumAllPublic())).
+		StringFlag("mode", "NON_HA", "Service mode [HA, NON_HA]").
 		StringFlag("out", "", "Output format of command, using golang's text/template engine. Entity fields: "+formatAllowedTemplateFields(entity.ServiceFields)).
 		StringFlag("env-file", "", "File with envs (will be set as secrets, runtime envs can be defined in zerops.yml). Max file size is "+units.ByteCountIEC(maxEnvFileSize)).
 		StringFlag("env-isolation", "service", "Env isolation rule [service, none] for more info see docs https://docs.zerops.io/features/env-variables#isolation-modes").
@@ -57,8 +56,8 @@ func serviceCreateCmd() *cmdBuilder.Cmd {
 
 			mode := cmdData.Params.GetString("mode")
 			mode = strings.ToUpper(mode)
-			if !enum.ServiceStackModeEnum(mode).Is(enum.ServiceStackModeEnumAllPublic()...) {
-				return errors.Errorf("Invalid --mode, expected one of %s, got %s", enum.ServiceStackModeEnumAllPublic(), mode)
+			if mode != "HA" && mode != "NON_HA" {
+				return errors.Errorf("Invalid --mode, expected one of [HA, NON_HA], got %s", mode)
 			}
 
 			envFile, err := readServiceEnvFile(cmdData)
@@ -102,7 +101,7 @@ func serviceCreateCmd() *cmdBuilder.Cmd {
 			postService := entity.PostService{
 				ProjectId:        project.Id,
 				Name:             types.NewString(name),
-				Mode:             enum.ServiceStackModeEnum(mode),
+				Mode:             types.NewString(mode),
 				EnvFile:          envFile,
 				StartWithoutCode: types.NewBool(startWithoutCode),
 				SshIsolation:     types.NewStringNull(cmdData.Params.GetString("ssh-isolation")),

--- a/src/cmdBuilder/scopeService.go
+++ b/src/cmdBuilder/scopeService.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zeropsio/zerops-go/apiError"
 	"github.com/zeropsio/zerops-go/errorCode"
 	"github.com/zeropsio/zerops-go/types"
-	"github.com/zeropsio/zerops-go/types/enum"
 	"github.com/zeropsio/zerops-go/types/uuid"
 )
 
@@ -199,7 +198,7 @@ func createNewService(ctx context.Context, project entity.Project, cmdData *Logg
 		entity.PostService{
 			ProjectId: project.Id,
 			Name:      types.NewString(name),
-			Mode:      enum.ServiceStackModeEnumNonHa,
+			Mode:      types.NewString("NON_HA"),
 			// Location:  location.Id.LocationIdNull(),
 		},
 	)

--- a/src/entity/repository/appVersion.go
+++ b/src/entity/repository/appVersion.go
@@ -2,12 +2,13 @@ package repository
 
 import (
 	"context"
+	"sort"
 
 	"github.com/zeropsio/zcli/src/entity"
 	"github.com/zeropsio/zcli/src/zeropsRestApiClient"
-	"github.com/zeropsio/zerops-go/dto/input/body"
+	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/dto/input/query"
 	"github.com/zeropsio/zerops-go/dto/output"
-	"github.com/zeropsio/zerops-go/types"
 )
 
 func GetAllAppVersionByService(
@@ -15,37 +16,25 @@ func GetAllAppVersionByService(
 	restApiClient *zeropsRestApiClient.Handler,
 	service entity.Service,
 ) ([]entity.AppVersion, error) {
-	esFilter := body.EsFilter{
-		Search: []body.EsSearchItem{
-			{
-				Name:     "clientId",
-				Operator: "eq",
-				Value:    service.OrgId.TypedString(),
-			}, {
-				Name:     "serviceStackId",
-				Operator: "eq",
-				Value:    service.Id.TypedString(),
-			}, {
-				Name:     "build.serviceStackId",
-				Operator: "ne",
-				Value:    "",
-			},
-		},
-	}
-
-	response, err := restApiClient.PostAppVersionSearch(ctx, esFilter)
+	response, err := restApiClient.GetServiceStackAppVersion(
+		ctx,
+		path.ServiceStackId{Id: service.Id},
+		query.ListServiceStackAppVersions{},
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	resOutput, err := response.Output()
+	versionList, err := response.Output()
 	if err != nil {
 		return nil, err
 	}
 
-	appVersions := make([]entity.AppVersion, 0, len(resOutput.Items))
-	for _, appVersion := range resOutput.Items {
-		appVersions = append(appVersions, appVersionFromEsSearch(appVersion))
+	appVersions := make([]entity.AppVersion, 0, len(versionList.List))
+	for _, v := range versionList.List {
+		if v.Build != nil {
+			appVersions = append(appVersions, appVersionFromListOutput(v))
+		}
 	}
 
 	return appVersions, nil
@@ -56,59 +45,49 @@ func GetLatestAppVersionByService(
 	restApiClient *zeropsRestApiClient.Handler,
 	service entity.Service,
 ) ([]entity.AppVersion, error) {
-	esFilter := body.EsFilter{
-		Search: []body.EsSearchItem{
-			{
-				Name:     "clientId",
-				Operator: "eq",
-				Value:    service.OrgId.TypedString(),
-			}, {
-				Name:     "serviceStackId",
-				Operator: "eq",
-				Value:    service.Id.TypedString(),
-			}, {
-				Name:     "build.serviceStackId",
-				Operator: "ne",
-				Value:    "",
-			},
-		},
-		Sort: []body.EsSortItem{
-			{
-				Name:      "sequence",
-				Ascending: types.NewBoolNull(false),
-			},
-		},
-		Limit: types.NewIntNull(1),
-	}
-
-	response, err := restApiClient.PostAppVersionSearch(ctx, esFilter)
-	if err != nil {
-		return nil, err
-	}
-	resOutput, err := response.Output()
+	response, err := restApiClient.GetServiceStackAppVersion(
+		ctx,
+		path.ServiceStackId{Id: service.Id},
+		query.ListServiceStackAppVersions{},
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	appVersions := make([]entity.AppVersion, 0, len(resOutput.Items))
-	for _, appVersion := range resOutput.Items {
-		appVersions = append(appVersions, appVersionFromEsSearch(appVersion))
+	versionList, err := response.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	appVersions := make([]entity.AppVersion, 0, len(versionList.List))
+	for _, v := range versionList.List {
+		if v.Build != nil {
+			appVersions = append(appVersions, appVersionFromListOutput(v))
+		}
+	}
+
+	sort.Slice(appVersions, func(i, j int) bool {
+		return appVersions[i].Sequence.Native() > appVersions[j].Sequence.Native()
+	})
+
+	if len(appVersions) > 1 {
+		appVersions = appVersions[:1]
 	}
 
 	return appVersions, nil
 }
 
-func appVersionFromEsSearch(esAppVersion output.EsAppVersion) entity.AppVersion {
+func appVersionFromListOutput(av output.GetAppVersion) entity.AppVersion {
 	return entity.AppVersion{
-		Id:         esAppVersion.Id,
-		OrgId:      esAppVersion.ClientId,
-		ProjectId:  esAppVersion.ProjectId,
-		ServiceId:  esAppVersion.ServiceStackId,
-		Source:     esAppVersion.Source,
-		Sequence:   esAppVersion.Sequence,
-		Status:     esAppVersion.Status,
-		Created:    esAppVersion.Created,
-		LastUpdate: esAppVersion.LastUpdate,
-		Build:      esAppVersion.Build,
+		Id:         av.Id,
+		OrgId:      av.ClientId,
+		ProjectId:  av.ProjectId,
+		ServiceId:  av.ServiceStackId,
+		Source:     av.Source,
+		Sequence:   av.Sequence,
+		Status:     av.Status,
+		Created:    av.Created,
+		LastUpdate: av.LastUpdate,
+		Build:      av.Build,
 	}
 }

--- a/src/entity/repository/container.go
+++ b/src/entity/repository/container.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/zeropsio/zcli/src/entity"
+	"github.com/zeropsio/zcli/src/gn"
 	"github.com/zeropsio/zcli/src/zeropsRestApiClient"
-	"github.com/zeropsio/zerops-go/dto/input/body"
+	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/dto/input/query"
 	"github.com/zeropsio/zerops-go/dto/output"
 )
 
@@ -14,48 +16,33 @@ func GetAllContainers(
 	restApiClient *zeropsRestApiClient.Handler,
 	service entity.Service,
 ) ([]entity.Container, error) {
-	esFilter := body.EsFilter{
-		Search: []body.EsSearchItem{
-			{
-				Name:     "clientId",
-				Operator: "eq",
-				Value:    service.OrgId.TypedString(),
-			}, {
-				Name:     "serviceStackId",
-				Operator: "eq",
-				Value:    service.Id.TypedString(),
-			},
-		},
-	}
-
-	response, err := restApiClient.PostContainerSearch(ctx, esFilter)
+	response, err := restApiClient.GetServiceStackContainer(
+		ctx,
+		path.ServiceStackId{Id: service.Id},
+		query.ListServiceStackContainers{},
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	resOutput, err := response.Output()
+	containerList, err := response.Output()
 	if err != nil {
 		return nil, err
 	}
 
-	containers := make([]entity.Container, 0, len(resOutput.Items))
-	for _, container := range resOutput.Items {
-		containers = append(containers, containerFromEsSearch(container))
-	}
-
-	return containers, nil
+	return gn.TransformSlice(containerList.List, containerFromListOutput), nil
 }
 
-func containerFromEsSearch(esContainer output.EsContainer) entity.Container {
+func containerFromListOutput(container output.Container) entity.Container {
 	return entity.Container{
-		Id:        esContainer.Id,
-		OrgId:     esContainer.ClientId,
-		ProjectId: esContainer.ProjectId,
-		ServiceId: esContainer.ServiceStackId,
-		Status:    esContainer.Status,
-		Number:    esContainer.Number,
-		Name:      esContainer.Name,
-		Hostname:  esContainer.Hostname,
-		Created:   esContainer.Created,
+		Id:        container.Id,
+		OrgId:     container.ClientId,
+		ProjectId: container.ProjectId,
+		ServiceId: container.ServiceStackId,
+		Status:    gn.Ptr(container.Status),
+		Number:    container.Number,
+		Name:      container.Name,
+		Hostname:  container.Hostname,
+		Created:   container.Created,
 	}
 }

--- a/src/entity/repository/process.go
+++ b/src/entity/repository/process.go
@@ -6,7 +6,8 @@ import (
 	"github.com/zeropsio/zcli/src/entity"
 	"github.com/zeropsio/zcli/src/gn"
 	"github.com/zeropsio/zcli/src/zeropsRestApiClient"
-	"github.com/zeropsio/zerops-go/dto/input/body"
+	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/dto/input/query"
 	"github.com/zeropsio/zerops-go/dto/output"
 	"github.com/zeropsio/zerops-go/types"
 	"github.com/zeropsio/zerops-go/types/uuid"
@@ -19,48 +20,23 @@ func GetProcessByActionNameAndProjectId(
 	projectId uuid.ProjectId,
 	actionName types.String,
 ) ([]entity.Process, error) {
-	search, err := restApiClient.PostProcessSearch(ctx, body.EsFilter{
-		Search: body.EsFilterSearch{
-			{
-				Name:     "clientId",
-				Operator: "eq",
-				Value:    orgId.TypedString(),
-			},
-			{
-				Name:     "projectId",
-				Operator: "eq",
-				Value:    projectId.TypedString(),
-			},
-			{
-				Name:     "actionName",
-				Operator: "eq",
-				Value:    actionName,
-			},
+	response, err := restApiClient.GetProjectProcess(
+		ctx,
+		path.ProjectId{Id: projectId},
+		query.ListProjectProcesses{
+			ActionNameContains: actionName.StringNull(),
 		},
-	})
+	)
 	if err != nil {
 		return nil, err
 	}
-	response, err := search.Output()
+	processList, err := response.Output()
 	if err != nil {
 		return nil, err
 	}
-	return gn.TransformSlice(response.Items, processFromEsSearch), nil
+	return gn.TransformSlice(processList.List, processFromApiOutput), nil
 }
 
-func processFromEsSearch(esProcess output.EsProcess) entity.Process {
-	return entity.Process{
-		Id:         esProcess.Id,
-		OrgId:      esProcess.ClientId,
-		ProjectId:  esProcess.ProjectId,
-		ServiceId:  esProcess.ServiceStackId,
-		ActionName: esProcess.ActionName,
-		Status:     esProcess.Status,
-		Sequence:   esProcess.Sequence,
-	}
-}
-
-//nolint:unused
 func processFromApiOutput(process output.Process) entity.Process {
 	return entity.Process{
 		Id:         process.Id,

--- a/src/entity/repository/project.go
+++ b/src/entity/repository/project.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/zeropsio/zcli/src/entity"
+	"github.com/zeropsio/zcli/src/gn"
 	"github.com/zeropsio/zcli/src/zeropsRestApiClient"
 	"github.com/zeropsio/zerops-go/dto/input/body"
 	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/dto/input/query"
 	"github.com/zeropsio/zerops-go/dto/output"
 	"github.com/zeropsio/zerops-go/types"
 	"github.com/zeropsio/zerops-go/types/uuid"
@@ -40,32 +42,29 @@ func GetAllProjects(
 		return nil, err
 	}
 
+	activeOrgs := gn.FilterSlice(orgs, func(o entity.Org) bool {
+		return o.Status.IsActive()
+	})
+
 	var projects []entity.Project
-	for _, org := range orgs {
-		if !org.Status.IsActive() {
-			continue
-		}
-		esFilter := body.EsFilter{
-			Search: []body.EsSearchItem{
-				{
-					Name:     "clientId",
-					Operator: "eq",
-					Value:    org.Id.TypedString(),
-				},
-			},
-		}
-
-		response, err := restApiClient.PostProjectSearch(ctx, esFilter)
+	for _, org := range activeOrgs {
+		response, err := restApiClient.GetClientProject(
+			ctx,
+			path.ClientId{Id: org.Id},
+			query.ListClientProjects{},
+		)
 		if err != nil {
 			return nil, err
 		}
-		projectsResponse, err := response.Output()
+		projectList, err := response.Output()
 		if err != nil {
 			return nil, err
 		}
 
-		for _, project := range projectsResponse.Items {
-			projects = append(projects, projectFromEsSearch(org, project))
+		for _, p := range projectList.List {
+			proj := projectFromApiOutput(p)
+			proj.OrgName = org.Name
+			projects = append(projects, proj)
 		}
 	}
 
@@ -97,20 +96,6 @@ func PostProject(
 		return entity.Project{}, err
 	}
 	return projectFromApiOutput(project), nil
-}
-
-func projectFromEsSearch(org entity.Org, esProject output.EsProject) entity.Project {
-	description, _ := esProject.Description.Get()
-
-	return entity.Project{
-		Id:          esProject.Id,
-		Name:        esProject.Name,
-		Mode:        esProject.Mode,
-		OrgId:       org.Id,
-		OrgName:     org.Name,
-		Description: description,
-		Status:      esProject.Status,
-	}
 }
 
 func projectFromApiOutput(project output.Project) entity.Project {

--- a/src/entity/repository/service.go
+++ b/src/entity/repository/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zeropsio/zerops-go/apiError"
 	"github.com/zeropsio/zerops-go/dto/input/body"
 	"github.com/zeropsio/zerops-go/dto/input/path"
+	"github.com/zeropsio/zerops-go/dto/input/query"
 	"github.com/zeropsio/zerops-go/dto/output"
 	"github.com/zeropsio/zerops-go/errorCode"
 	"github.com/zeropsio/zerops-go/types"
@@ -92,35 +93,24 @@ func GetNonSystemServicesByProject(
 	restApiClient *zeropsRestApiClient.Handler,
 	project entity.Project,
 ) ([]entity.Service, error) {
-	esFilter := body.EsFilter{
-		Search: []body.EsSearchItem{
-			{
-				Name:     "projectId",
-				Operator: "eq",
-				Value:    project.Id.TypedString(),
-			},
-			{
-				Name:     "clientId",
-				Operator: "eq",
-				Value:    project.OrgId.TypedString(),
-			},
-		},
-	}
-
-	servicesResponse, err := restApiClient.PostServiceStackSearch(ctx, esFilter)
+	response, err := restApiClient.GetProjectServiceStack(
+		ctx,
+		path.ProjectId{Id: project.Id},
+		query.ListProjectServiceStacks{},
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	servicesOutput, err := servicesResponse.Output()
+	serviceList, err := response.Output()
 	if err != nil {
 		return nil, err
 	}
 
-	services := make([]entity.Service, 0, len(servicesOutput.Items))
-	for _, service := range servicesOutput.Items {
+	services := make([]entity.Service, 0, len(serviceList.List))
+	for _, service := range serviceList.List {
 		if !service.IsSystem {
-			services = append(services, serviceFromEsSearch(service))
+			services = append(services, serviceFromApiOutput(service))
 		}
 	}
 
@@ -133,15 +123,15 @@ func PostGenericService(
 	post entity.PostService,
 ) (entity.Process, entity.Service, error) {
 	postBody := body.PostStandardServiceStack{
-		Name:             post.Name,
-		Mode:             &post.Mode,
+			Name:             post.Name,
+			Mode:             post.Mode.StringNull(),
 		UserDataEnvFile:  post.EnvFile,
 		StartWithoutCode: types.NewBoolNull(post.StartWithoutCode.Native()),
 		EnvIsolation:     post.EnvIsolation,
 		SshIsolation:     post.SshIsolation,
 		Location:         post.Location,
 	}
-	response, err := restApiClient.PostProjectServiceStack(
+	response, err := restApiClient.PostProjectServiceStackOld(
 		ctx,
 		path.ServiceStackServiceStackTypeVersionId{
 			Id:                        post.ProjectId,
@@ -160,19 +150,6 @@ func PostGenericService(
 
 	return processFromApiOutput(serviceStackProcess.Process), serviceFromApiPostOutput(serviceStackProcess), nil
 }
-func serviceFromEsSearch(esServiceStack output.EsServiceStack) entity.Service {
-	return entity.Service{
-		Id:                          esServiceStack.Id,
-		ProjectId:                   esServiceStack.ProjectId,
-		OrgId:                       esServiceStack.ClientId,
-		Name:                        esServiceStack.Name,
-		Status:                      esServiceStack.Status,
-		ServiceTypeId:               esServiceStack.ServiceStackTypeId,
-		ServiceTypeCategory:         esServiceStack.ServiceStackTypeInfo.ServiceStackTypeCategory,
-		ServiceStackTypeVersionName: esServiceStack.ServiceStackTypeInfo.ServiceStackTypeVersionName,
-	}
-}
-
 func serviceFromApiOutput(service output.ServiceStack) entity.Service {
 	return entity.Service{
 		Id:                          service.Id,

--- a/src/entity/service.go
+++ b/src/entity/service.go
@@ -23,7 +23,7 @@ var ServiceFields = entityTemplateFields[Service]()
 type PostService struct {
 	ProjectId        uuid.ProjectId
 	Name             types.String
-	Mode             enum.ServiceStackModeEnum
+	Mode             types.String
 	EnvFile          types.TextNull
 	StartWithoutCode types.Bool
 	SshIsolation     types.StringNull


### PR DESCRIPTION
Bumps `github.com/zeropsio/zerops-go` from v1.0.14 to v1.0.19 and migrates all /search API calls to the new RESTful read/list endpoints.

Changes:
- `project/search` → `/client/{clientId}/project`
- `service/search` → `/project/{projectId}/service`
- `process/search` → `/service/{serviceId}/process`
- `container/search` → `/process/{processId}/container`
- `appVersion/search` → `/service/{serviceId}/app-version`
- `PostService.Mode` type changed to match v1.0.19 (now `types.String`)

Closes #255